### PR TITLE
Document DMRG mindim default

### DIFF
--- a/src/solver.jl
+++ b/src/solver.jl
@@ -127,7 +127,7 @@ Keyword arguments:
 - `maxdim` - The maximum allowed bond dimension.
   Integer or array of integer specifying the bond dimension per iteration.
   You can use this keyword to control the solver's accuracy vs resources trade-off.
-- `mindim` - The minimum allowed bond dimension, if possible.
+- `mindim` - The minimum allowed bond dimension, if possible.  Defaults to `1`.
   Integer or array of integer specifying the bond dimension per iteration.
 - `time_limit :: Float64` - If specified, determines the maximum running time in seconds.
   It only determines whether a new iteration should start or not, thus the solver may run for longer if the threshold happens during an iteration.


### PR DESCRIPTION
## Summary

- Merge current `main` into this branch with an append-only merge commit.
- Drop the stale single-variable QUBO implementation and test from this branch because that behavior already landed on `main` via #49.
- Restore the VRP `mindim = 2` workaround, so this PR no longer claims to fix the LAPACK/KrylovKit instability from #1.
- Document that the current DMRG `mindim` default is `1`.

## Tests run

- `git diff --check`
  - Result: passed.
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`
  - Result: passed.

## Notes

- Refs #1. The Anvil-specific LAPACK/KrylovKit behavior remains a follow-up/root-cause issue.
