### PR TITLE
Solve single-variable QUBO inputs exactly instead of crashing

### DIFF
--- a/src/solver.jl
+++ b/src/solver.jl
@@ -184,6 +184,37 @@ function minimize(p::AbstractPolynomial{T}; cutoff=1e-8, kwargs...) where T
   return _minimize(H, cte, a -> p(vs => a); cutoff, kwargs...)
 end
 
+function _single_variable_minimize(::Type{T}, sites, obj, initial_time; device, verbosity, on_iteration, callback_every) where {T}
+  x0 = [0]
+  x1 = [1]
+  e0 = obj(x0)
+  e1 = obj(x1)
+
+  energy, state = if e0 == e1
+    (T(e0), ["full"])
+  elseif e0 < e1
+    (T(e0), string.(x0))
+  else
+    (T(e1), string.(x1))
+  end
+
+  psi = ITensorMPS.MPS(sites, state) |> device
+  elapsed_time = time() - initial_time
+  bond_dim = ITensorMPS.maxlinkdim(psi)
+
+  iterlog_header(verbosity)
+  iterlog_iteration(verbosity, 1, energy, bond_dim, 0.0, elapsed_time)
+
+  dist = Solution{T}(psi, T[energy], Int[bond_dim], Float64[elapsed_time])
+  if !isnothing(on_iteration) && 1 % callback_every == 0
+    on_iteration(psi; iteration=1, objective=energy, bond_dim, elapsed_time)
+  end
+
+  iterlog_footer(verbosity, energy, elapsed_time)
+
+  return energy, dist
+end
+
 function _minimize( H :: MPO
                   , c :: T
                   , obj
@@ -215,6 +246,10 @@ function _minimize( H :: MPO
 
   # Quantization
   sites = ITensorMPS.siteinds(first, H; plev=0)
+  if length(sites) == 1
+    return _single_variable_minimize(T, sites, obj, initial_time; device, verbosity, on_iteration, callback_every)
+  end
+
   H     = device(H)
   psi   = ITensorMPS.random_mps(T, sites; linkdims=inidim) |> device
 

--- a/test/qubo.jl
+++ b/test/qubo.jl
@@ -43,6 +43,42 @@
       @test TenSolver.sample(psi) == [0, 1]
     end
 
+    @testset "Single variable" begin
+      Q = reshape([-2.0], 1, 1)
+      E, psi = minimize(Q)
+
+      @test E ≈ -2.0
+      @test TenSolver.sample(psi) == [1]
+      @test psi.energies == [-2.0]
+      @test psi.bond_dims == [1]
+      @test length(psi.elapsed_times) == 1
+    end
+
+    @testset "Single variable with linear and constant terms" begin
+      Q = reshape([0.0], 1, 1)
+      E, psi = minimize(Q, [-3.0], 2.0)
+
+      @test E ≈ -1.0
+      @test TenSolver.sample(psi) == [1]
+    end
+
+    @testset "Single variable degeneracy" begin
+      Q = reshape([0.0], 1, 1)
+      E, psi = minimize(Q)
+
+      @test E ≈ 0.0
+      @test [0] in psi
+      @test [1] in psi
+    end
+
+    @testset "Max: Single variable" begin
+      Q = reshape([2.0], 1, 1)
+      E, psi = maximize(Q)
+
+      @test E ≈ 2.0
+      @test TenSolver.sample(psi) == [1]
+    end
+
     @testset "Identity" begin
       E, psi = minimize([1.0 0.0; 0.0 1.0])
 


### PR DESCRIPTION
## Summary

`minimize`/`maximize` crashed on single-variable (1x1) QUBO inputs because the underlying ITensor DMRG solver does not support system sizes of 1:

```
ERROR: `dmrg` currently does not support system sizes of 1.
```

This adds an exact single-variable path in `_minimize`: when the tensorized Hamiltonian has one site, it evaluates the objective at `x = 0` and `x = 1`, returns the minimizer's energy (or reports degeneracy as a uniform superposition when the two are equal), and constructs a `Solution` consistent with the multi-variable path (energies/bond_dims/elapsed_times populated, iteration log and `on_iteration` callback honored). No public API or default behavior changes for multi-variable inputs.

This edge case currently has slightly divergent ad hoc fixes duplicated across open PRs #32, #33, #34, and #41. Landing it once here lets those PRs drop their copies and avoids merge conflicts.

## Tests

Added four testsets to `test/qubo.jl` under "QUBO Correctness": single variable, single variable with linear and constant terms, single-variable degeneracy, and single-variable maximize. On unmodified `main` the first of these throws (`dmrg ... system sizes of 1`); with this change they pass.

Commands and results (Julia 1.10.11):

- Reproduction on `main` (clean re-resolved env): `minimize(reshape([-2.0], 1, 1))` throws `ErrorException: dmrg currently does not support system sizes of 1`.
- `julia --project=. -e 'using Pkg; Pkg.test()'` on this branch: passed (`Testing TenSolver tests passed`), `QUBO Correctness` 82/82 (was 78 on `main`), all other testsets green (Ill-formed input, PUBO, Logging, JuMP, QUBODrivers.jl, Aqua.jl, VRP, HDF5, Doctests).

## Notes

- Local `Manifest.toml` files are gitignored and must be re-resolved for the active Julia version; a stale 1.12-resolved manifest causes `Pkg.test()` to fail on 1.10. Removing it forces a fresh resolve, which is what CI does. No manifest is committed.
- No new dependencies; no CI/workflow changes.

Closes #49
