### PR TITLE
Modernize Julia CI action pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,15 +40,15 @@ jobs:
             arch: x64
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v6
         with:
           files: lcov.info


### PR DESCRIPTION
## Summary

- Modernizes CI action majors while preserving the existing Julia version, OS, and architecture matrix.
- Updates `actions/checkout` from v4 to v6, `julia-actions/setup-julia` from v2 to v3, `julia-actions/cache` from v2 to v3, and `codecov/codecov-action` from v2 to v6.
- Keeps `julia-actions/julia-buildpkg@v1`, `julia-actions/julia-runtest@v1`, and `julia-actions/julia-processcoverage@v1`.

## Compatibility Notes

- Verified action metadata with `gh api`: Julia setup v3 still accepts `version` and `arch`; Julia cache v3 preserves default cache restore/save behavior; Codecov v6 still accepts `files`.
- No permissions or CI matrix changes were made.
- The updated checkout/setup/cache action majors use the current Node 24 action runtime on GitHub-hosted runners.
- The Codecov major update crosses the v3+ token-handling changes; the current PR CI confirms this repository's coverage upload still completes without additional token/configuration changes.

## Tests

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parses"'` passed.
- `git diff --check` passed.
- `julia +release --project=. -e 'using Pkg; Pkg.test()'` passed locally while reviewing current head `120c62a`.

## CI

- Current head: `120c62a`.
- Run tests workflow `27481946465` passed all nine matrix jobs across Ubuntu, Windows, and macOS aarch64.
- In the passing matrix jobs, `actions/checkout@v6`, `julia-actions/setup-julia@v3`, `julia-actions/cache@v3`, and `codecov/codecov-action@v6` completed successfully; the cache post step also completed successfully.
- Documentation workflow `27481946460` passed, and `documenter/deploy` reported success for the PR preview.

Closes #48
