### PR TITLE
Add binary constraint API

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -38,6 +38,21 @@ TenSolver.qubo_to_ising
 TenSolver.ising_to_qubo
 ```
 
+## Constraints
+
+```@docs
+TenSolver.AbstractConstraint
+TenSolver.SumConstraint
+TenSolver.NotEqualsConstraint
+TenSolver.ExactlyOneConstraint
+TenSolver.RelationConstraint
+TenSolver.sum_constraint
+TenSolver.not_equals_constraint
+TenSolver.exactly_one_constraint
+TenSolver.relation_constraint
+TenSolver.is_feasible
+```
+
 ## Utility Functions
 
 ```@docs

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -46,10 +46,6 @@ TenSolver.SumConstraint
 TenSolver.NotEqualsConstraint
 TenSolver.ExactlyOneConstraint
 TenSolver.RelationConstraint
-TenSolver.sum_constraint
-TenSolver.not_equals_constraint
-TenSolver.exactly_one_constraint
-TenSolver.relation_constraint
 TenSolver.is_feasible
 ```
 

--- a/src/TenSolver.jl
+++ b/src/TenSolver.jl
@@ -18,7 +18,6 @@ export bool_to_spin, spin_to_bool, qubo_to_ising, ising_to_qubo
 include("constraints.jl")
 export AbstractConstraint
 export SumConstraint, NotEqualsConstraint, ExactlyOneConstraint, RelationConstraint
-export sum_constraint, not_equals_constraint, exactly_one_constraint, relation_constraint
 export is_feasible
 
 include("solver.jl")

--- a/src/TenSolver.jl
+++ b/src/TenSolver.jl
@@ -15,6 +15,12 @@ include("preprocess.jl")
 include("ising.jl")
 export bool_to_spin, spin_to_bool, qubo_to_ising, ising_to_qubo
 
+include("constraints.jl")
+export AbstractConstraint
+export SumConstraint, NotEqualsConstraint, ExactlyOneConstraint, RelationConstraint
+export sum_constraint, not_equals_constraint, exactly_one_constraint, relation_constraint
+export is_feasible
+
 include("solver.jl")
 export minimize, maximize
 export DMRGBackend

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1,0 +1,189 @@
+abstract type AbstractConstraint end
+
+struct SumConstraint{T<:Real} <: AbstractConstraint
+  sites::Vector{Int}
+  weights::Vector{T}
+  relation::Symbol
+  rhs::T
+
+  function SumConstraint{T}(
+    sites::AbstractVector{<:Integer},
+    weights::AbstractVector{T},
+    relation::Symbol,
+    rhs::T,
+  ) where {T<:Real}
+    site_vec = _validate_sites(sites)
+    weight_vec = _validate_weights(weights)
+    _validate_same_length(site_vec, weight_vec, "sites", "weights")
+    relation = _validate_relation(relation)
+
+    return new{T}(site_vec, weight_vec, relation, rhs)
+  end
+end
+
+function SumConstraint(sites, weights, relation, rhs)
+  site_vec = _validate_sites(sites)
+  raw_weights = collect(weights)
+  isempty(raw_weights) && throw(ArgumentError("weights must not be empty"))
+
+  weight_types = map(typeof, raw_weights)
+  T = promote_type(weight_types..., typeof(rhs))
+  T <: Real || throw(ArgumentError("weights and rhs must be real-valued"))
+
+  weight_vec = T.(raw_weights)
+  rhs_value = convert(T, rhs)
+
+  return SumConstraint{T}(site_vec, weight_vec, _validate_relation(relation), rhs_value)
+end
+
+struct NotEqualsConstraint <: AbstractConstraint
+  sites::Vector{Int}
+  values::Vector{Int}
+
+  function NotEqualsConstraint(sites, values)
+    site_vec = _validate_sites(sites)
+    value_vec = _validate_binary_values(values, "values")
+    _validate_same_length(site_vec, value_vec, "sites", "values")
+
+    return new(site_vec, value_vec)
+  end
+end
+
+struct ExactlyOneConstraint <: AbstractConstraint
+  sites::Vector{Int}
+
+  function ExactlyOneConstraint(sites)
+    return new(_validate_sites(sites))
+  end
+end
+
+struct RelationConstraint <: AbstractConstraint
+  left_site::Int
+  relation::Symbol
+  right_site::Int
+
+  function RelationConstraint(left_site, relation, right_site)
+    left = _validate_site(left_site, "left_site")
+    right = _validate_site(right_site, "right_site")
+    left == right && throw(ArgumentError("relation constraint sites must be distinct"))
+
+    return new(left, _validate_relation(relation), right)
+  end
+end
+
+sum_constraint(sites, weights, relation, rhs) = SumConstraint(sites, weights, relation, rhs)
+sum_constraint(sites, weights, rhs; relation=Symbol("==")) = SumConstraint(sites, weights, relation, rhs)
+not_equals_constraint(sites, values) = NotEqualsConstraint(sites, values)
+exactly_one_constraint(sites) = ExactlyOneConstraint(sites)
+relation_constraint(left_site, relation, right_site) = RelationConstraint(left_site, relation, right_site)
+
+function is_feasible(x::AbstractVector, constraint::SumConstraint)
+  lhs = sum(
+    constraint.weights[i] * _binary_at(x, constraint.sites[i])
+    for i in eachindex(constraint.sites, constraint.weights)
+  )
+
+  return _relation_holds(lhs, constraint.relation, constraint.rhs)
+end
+
+function is_feasible(x::AbstractVector, constraint::NotEqualsConstraint)
+  return any(
+    _binary_at(x, constraint.sites[i]) != constraint.values[i]
+    for i in eachindex(constraint.sites, constraint.values)
+  )
+end
+
+function is_feasible(x::AbstractVector, constraint::ExactlyOneConstraint)
+  return sum(_binary_at(x, site) for site in constraint.sites) == 1
+end
+
+function is_feasible(x::AbstractVector, constraint::RelationConstraint)
+  lhs = _binary_at(x, constraint.left_site)
+  rhs = _binary_at(x, constraint.right_site)
+
+  return _relation_holds(lhs, constraint.relation, rhs)
+end
+
+function is_feasible(x::AbstractVector, constraints::AbstractVector{<:AbstractConstraint})
+  return all(constraint -> is_feasible(x, constraint), constraints)
+end
+
+const _VALID_RELATIONS = (
+  Symbol("=="),
+  Symbol("!="),
+  Symbol("<"),
+  Symbol("<="),
+  Symbol(">"),
+  Symbol(">="),
+)
+
+function _validate_site(site, name)
+  site isa Integer || throw(ArgumentError("$name must be an integer"))
+  site > 0 || throw(ArgumentError("$name must be a positive integer"))
+
+  return Int(site)
+end
+
+function _validate_sites(sites)
+  site_vec = collect(sites)
+  isempty(site_vec) && throw(ArgumentError("sites must not be empty"))
+
+  validated = [_validate_site(site, "sites") for site in site_vec]
+  length(unique(validated)) == length(validated) ||
+    throw(ArgumentError("sites must be unique"))
+
+  return validated
+end
+
+function _validate_same_length(left, right, left_name, right_name)
+  length(left) == length(right) ||
+    throw(DimensionMismatch("$left_name and $right_name must have the same length"))
+
+  return nothing
+end
+
+function _validate_weights(weights)
+  weight_vec = collect(weights)
+  isempty(weight_vec) && throw(ArgumentError("weights must not be empty"))
+  all(weight -> weight >= 0, weight_vec) ||
+    throw(ArgumentError("weights must be nonnegative"))
+
+  return weight_vec
+end
+
+function _validate_relation(relation)
+  relation isa Symbol || throw(ArgumentError("relation must be a Symbol"))
+  relation in _VALID_RELATIONS ||
+    throw(ArgumentError("relation must be one of: $(join(string.(_VALID_RELATIONS), ", "))"))
+
+  return relation
+end
+
+function _validate_binary_values(values, name)
+  value_vec = collect(values)
+  isempty(value_vec) && throw(ArgumentError("$name must not be empty"))
+  all(value -> value == 0 || value == 1, value_vec) ||
+    throw(ArgumentError("$name must contain only binary values 0 or 1"))
+
+  return Int.(value_vec)
+end
+
+function _binary_at(x, site)
+  checkbounds(x, site)
+  value = x[site]
+  value == 0 || value == 1 ||
+    throw(ArgumentError("x must contain only binary values 0 or 1"))
+
+  return Int(value)
+end
+
+function _relation_holds(lhs, relation, rhs)
+  relation === Symbol("==") && return lhs == rhs
+  relation === Symbol("!=") && return lhs != rhs
+  relation === Symbol("<") && return lhs < rhs
+  relation === Symbol("<=") && return lhs <= rhs
+  relation === Symbol(">") && return lhs > rhs
+  relation === Symbol(">=") && return lhs >= rhs
+
+  error("unsupported relation: $relation")
+end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -25,12 +25,7 @@ struct SumConstraint{T<:Real} <: AbstractConstraint
   relation::Symbol
   rhs::T
 
-  function SumConstraint{T}(
-    sites::AbstractVector{<:Integer},
-    weights::AbstractVector{T},
-    relation::Symbol,
-    rhs::T,
-  ) where {T<:Real}
+  function SumConstraint{T}(sites, weights, relation, rhs::T) where {T<:Real}
     site_vec = _validate_sites(sites)
     weight_vec = _validate_weights(weights)
     _validate_same_length(site_vec, weight_vec, "sites", "weights")
@@ -41,7 +36,6 @@ struct SumConstraint{T<:Real} <: AbstractConstraint
 end
 
 function SumConstraint(sites, weights, relation, rhs)
-  site_vec = _validate_sites(sites)
   raw_weights = collect(weights)
   isempty(raw_weights) && throw(ArgumentError("weights must not be empty"))
 
@@ -52,7 +46,8 @@ function SumConstraint(sites, weights, relation, rhs)
   weight_vec = T.(raw_weights)
   rhs_value = convert(T, rhs)
 
-  return SumConstraint{T}(site_vec, weight_vec, _validate_relation(relation), rhs_value)
+  # `sites` and `relation` are validated once, inside the inner constructor.
+  return SumConstraint{T}(sites, weight_vec, relation, rhs_value)
 end
 
 """
@@ -249,6 +244,11 @@ end
 function _validate_weights(weights)
   weight_vec = collect(weights)
   isempty(weight_vec) && throw(ArgumentError("weights must not be empty"))
+  # Nonnegativity is a deliberate v1 contract (issue #56 acceptance criteria):
+  # it keeps the predicate aligned with the nonnegative projection targets used
+  # by the constraint/MPO work tracked in #57. Signed weights (e.g. encoding a
+  # difference `x1 - x2 == 0`) are intentionally out of scope here and should be
+  # revisited together with that lowering, not relaxed in isolation.
   all(weight -> weight >= 0, weight_vec) ||
     throw(ArgumentError("weights must be nonnegative"))
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1,5 +1,24 @@
+"""
+    AbstractConstraint
+
+Supertype for the binary feasibility constraints understood by
+[`is_feasible`](@ref).
+
+Concrete subtypes are [`SumConstraint`](@ref), [`NotEqualsConstraint`](@ref),
+[`ExactlyOneConstraint`](@ref), and [`RelationConstraint`](@ref). Each describes
+a condition over a binary vector `x` (entries in `{0, 1}`) addressed by 1-based
+site indices.
+"""
 abstract type AbstractConstraint end
 
+"""
+    SumConstraint{T} <: AbstractConstraint
+
+Weighted-sum constraint `sum(weights .* x[sites]) <relation> rhs` over a binary
+vector `x`, where `relation` is one of `:(==)`, `:(!=)`, `:(<)`, `:(<=)`,
+`:(>)`, `:(>=)`. Sites must be unique positive integers and weights nonnegative.
+Build instances with [`sum_constraint`](@ref).
+"""
 struct SumConstraint{T<:Real} <: AbstractConstraint
   sites::Vector{Int}
   weights::Vector{T}
@@ -36,6 +55,13 @@ function SumConstraint(sites, weights, relation, rhs)
   return SumConstraint{T}(site_vec, weight_vec, _validate_relation(relation), rhs_value)
 end
 
+"""
+    NotEqualsConstraint <: AbstractConstraint
+
+Excludes a single assignment: `x[sites]` must differ from `values` in at least
+one position, i.e. the exact partial assignment `x[sites] == values` is
+forbidden. Build instances with [`not_equals_constraint`](@ref).
+"""
 struct NotEqualsConstraint <: AbstractConstraint
   sites::Vector{Int}
   values::Vector{Int}
@@ -49,6 +75,12 @@ struct NotEqualsConstraint <: AbstractConstraint
   end
 end
 
+"""
+    ExactlyOneConstraint <: AbstractConstraint
+
+Requires exactly one of `x[sites]` to equal `1`. Build instances with
+[`exactly_one_constraint`](@ref).
+"""
 struct ExactlyOneConstraint <: AbstractConstraint
   sites::Vector{Int}
 
@@ -57,6 +89,13 @@ struct ExactlyOneConstraint <: AbstractConstraint
   end
 end
 
+"""
+    RelationConstraint <: AbstractConstraint
+
+Pairwise constraint `x[left_site] <relation> x[right_site]` between two distinct
+sites, where `relation` is one of `:(==)`, `:(!=)`, `:(<)`, `:(<=)`, `:(>)`,
+`:(>=)`. Build instances with [`relation_constraint`](@ref).
+"""
 struct RelationConstraint <: AbstractConstraint
   left_site::Int
   relation::Symbol
@@ -71,12 +110,77 @@ struct RelationConstraint <: AbstractConstraint
   end
 end
 
+"""
+    sum_constraint(sites, weights, relation, rhs)
+    sum_constraint(sites, weights, rhs; relation = :(==))
+
+Construct a [`SumConstraint`](@ref) `sum(weights .* x[sites]) <relation> rhs`.
+
+Two call forms are supported. In the four-argument form the relation is the
+third positional argument. In the three-argument form `rhs` is the third
+positional argument and the relation is the `relation` keyword (default
+`:(==)`); passing a relation positionally to this form is an error rather than a
+silently misinterpreted `rhs`.
+
+`sites` must be unique positive integers, `weights` nonnegative and the same
+length as `sites`, and `relation` one of `:(==)`, `:(!=)`, `:(<)`, `:(<=)`,
+`:(>)`, `:(>=)`.
+
+```julia
+sum_constraint([1, 2, 3], [2, 1, 1], :(<=), 3)
+sum_constraint([1, 2], [1, 1], 1)            # relation defaults to :(==)
+```
+"""
 sum_constraint(sites, weights, relation, rhs) = SumConstraint(sites, weights, relation, rhs)
-sum_constraint(sites, weights, rhs; relation=Symbol("==")) = SumConstraint(sites, weights, relation, rhs)
+
+function sum_constraint(sites, weights, rhs; relation=Symbol("=="))
+  rhs isa Symbol && throw(ArgumentError(
+    "sum_constraint(sites, weights, rhs; relation) takes `rhs` as the third " *
+    "positional argument and `relation` as a keyword. To pass a relation " *
+    "positionally, use the four-argument form " *
+    "sum_constraint(sites, weights, relation, rhs).",
+  ))
+
+  return SumConstraint(sites, weights, relation, rhs)
+end
+
+"""
+    not_equals_constraint(sites, values)
+
+Construct a [`NotEqualsConstraint`](@ref) forbidding `x[sites] == values`.
+`values` must be binary (`0` or `1`) and the same length as `sites`.
+"""
 not_equals_constraint(sites, values) = NotEqualsConstraint(sites, values)
+
+"""
+    exactly_one_constraint(sites)
+
+Construct an [`ExactlyOneConstraint`](@ref) requiring exactly one of `x[sites]`
+to equal `1`.
+"""
 exactly_one_constraint(sites) = ExactlyOneConstraint(sites)
+
+"""
+    relation_constraint(left_site, relation, right_site)
+
+Construct a [`RelationConstraint`](@ref)
+`x[left_site] <relation> x[right_site]`. The two sites must be distinct positive
+integers and `relation` one of `:(==)`, `:(!=)`, `:(<)`, `:(<=)`, `:(>)`,
+`:(>=)`.
+"""
 relation_constraint(left_site, relation, right_site) = RelationConstraint(left_site, relation, right_site)
 
+"""
+    is_feasible(x, constraint)
+    is_feasible(x, constraints)
+
+Test whether the binary vector `x` (entries in `{0, 1}`, 1-based indexing)
+satisfies a single `constraint <: AbstractConstraint` or every constraint in a
+vector `constraints`. An empty constraint vector is feasible.
+
+Throws an `ArgumentError` if `x` contains a non-binary entry and a `BoundsError`
+if a constraint references a site outside `x`.
+"""
 function is_feasible(x::AbstractVector, constraint::SumConstraint)
   lhs = sum(
     constraint.weights[i] * _binary_at(x, constraint.sites[i])

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -30,10 +30,10 @@ struct SumConstraint{T<:Real} <: AbstractConstraint
   rhs::T
 
   function SumConstraint{T}(sites, weights, relation, rhs::T) where {T<:Real}
-    site_vec = _validate_sites(sites)
-    weight_vec = _validate_weights(weights)
-    _validate_same_length(site_vec, weight_vec, "sites", "weights")
-    relation = _validate_relation(relation)
+    site_vec = validate_sites(sites)
+    weight_vec = validate_weights(weights)
+    validate_same_length(site_vec, weight_vec, "sites", "weights")
+    relation = validate_relation(relation)
 
     return new{T}(site_vec, weight_vec, relation, rhs)
   end
@@ -74,9 +74,9 @@ struct NotEqualsConstraint <: AbstractConstraint
   values::Vector{Int}
 
   function NotEqualsConstraint(sites, values)
-    site_vec = _validate_sites(sites)
-    value_vec = _validate_binary_values(values, "values")
-    _validate_same_length(site_vec, value_vec, "sites", "values")
+    site_vec = validate_sites(sites)
+    value_vec = validate_binary_values(values, "values")
+    validate_same_length(site_vec, value_vec, "sites", "values")
 
     return new(site_vec, value_vec)
   end
@@ -93,7 +93,7 @@ struct ExactlyOneConstraint <: AbstractConstraint
   sites::Vector{Int}
 
   function ExactlyOneConstraint(sites)
-    return new(_validate_sites(sites))
+    return new(validate_sites(sites))
   end
 end
 
@@ -113,11 +113,11 @@ struct RelationConstraint <: AbstractConstraint
   right_site::Int
 
   function RelationConstraint(left_site, relation, right_site)
-    left = _validate_site(left_site, "left_site")
-    right = _validate_site(right_site, "right_site")
+    left = validate_site(left_site, "left_site")
+    right = validate_site(right_site, "right_site")
     left == right && throw(ArgumentError("relation constraint sites must be distinct"))
 
-    return new(left, _validate_relation(relation), right)
+    return new(left, validate_relation(relation), right)
   end
 end
 
@@ -132,29 +132,29 @@ if a constraint references a site outside `x`.
 """
 function is_feasible(x::AbstractVector, constraint::SumConstraint)
   lhs = sum(
-    constraint.weights[i] * _binary_at(x, constraint.sites[i])
+    constraint.weights[i] * binary_at(x, constraint.sites[i])
     for i in eachindex(constraint.sites, constraint.weights)
   )
 
-  return _relation_holds(lhs, constraint.relation, constraint.rhs)
+  return relation_holds(lhs, constraint.relation, constraint.rhs)
 end
 
 function is_feasible(x::AbstractVector, constraint::NotEqualsConstraint)
   return any(
-    _binary_at(x, constraint.sites[i]) != constraint.values[i]
+    binary_at(x, constraint.sites[i]) != constraint.values[i]
     for i in eachindex(constraint.sites, constraint.values)
   )
 end
 
 function is_feasible(x::AbstractVector, constraint::ExactlyOneConstraint)
-  return sum(_binary_at(x, site) for site in constraint.sites) == 1
+  return sum(binary_at(x, site) for site in constraint.sites) == 1
 end
 
 function is_feasible(x::AbstractVector, constraint::RelationConstraint)
-  lhs = _binary_at(x, constraint.left_site)
-  rhs = _binary_at(x, constraint.right_site)
+  lhs = binary_at(x, constraint.left_site)
+  rhs = binary_at(x, constraint.right_site)
 
-  return _relation_holds(lhs, constraint.relation, rhs)
+  return relation_holds(lhs, constraint.relation, rhs)
 end
 
 """
@@ -171,39 +171,44 @@ function is_feasible(x::AbstractVector, constraints::AbstractVector{<:AbstractCo
   return all(constraint -> is_feasible(x, constraint), constraints)
 end
 
-const _VALID_RELATIONS = (
+
+#----------------------------------------------------------#
+# Constraint Validation
+#----------------------------------------------------------#
+
+const VALID_RELATIONS = (
   Symbol("=="),
   Symbol("!="),
   Symbol("<="),
   Symbol(">="),
 )
 
-function _validate_site(site, name)
+function validate_site(site, name)
   site isa Integer || throw(ArgumentError("$name must be an integer"))
   site > 0 || throw(ArgumentError("$name must be a positive integer"))
 
   return Int(site)
 end
 
-function _validate_sites(sites)
+function validate_sites(sites)
   site_vec = collect(sites)
   isempty(site_vec) && throw(ArgumentError("sites must not be empty"))
 
-  validated = [_validate_site(site, "sites") for site in site_vec]
+  validated = [validate_site(site, "sites") for site in site_vec]
   length(unique(validated)) == length(validated) ||
     throw(ArgumentError("sites must be unique"))
 
   return validated
 end
 
-function _validate_same_length(left, right, left_name, right_name)
+function validate_same_length(left, right, left_name, right_name)
   length(left) == length(right) ||
     throw(DimensionMismatch("$left_name and $right_name must have the same length"))
 
   return nothing
 end
 
-function _validate_weights(weights)
+function validate_weights(weights)
   weight_vec = collect(weights)
   isempty(weight_vec) && throw(ArgumentError("weights must not be empty"))
   # Nonnegativity is a deliberate v1 contract (issue #56 acceptance criteria):
@@ -217,15 +222,15 @@ function _validate_weights(weights)
   return weight_vec
 end
 
-function _validate_relation(relation)
+function validate_relation(relation)
   relation isa Symbol || throw(ArgumentError("relation must be a Symbol"))
-  relation in _VALID_RELATIONS ||
-    throw(ArgumentError("relation must be one of: $(join(string.(_VALID_RELATIONS), ", "))"))
+  relation in VALID_RELATIONS ||
+    throw(ArgumentError("relation must be one of: $(join(string.(VALID_RELATIONS), ", "))"))
 
   return relation
 end
 
-function _validate_binary_values(values, name)
+function validate_binary_values(values, name)
   value_vec = collect(values)
   isempty(value_vec) && throw(ArgumentError("$name must not be empty"))
   all(value -> value == 0 || value == 1, value_vec) ||
@@ -234,7 +239,7 @@ function _validate_binary_values(values, name)
   return Int.(value_vec)
 end
 
-function _binary_at(x, site)
+function binary_at(x, site)
   checkbounds(x, site)
   value = x[site]
   value == 0 || value == 1 ||
@@ -243,7 +248,7 @@ function _binary_at(x, site)
   return Int(value)
 end
 
-function _relation_holds(lhs, relation, rhs)
+function relation_holds(lhs, relation, rhs)
   relation === Symbol("==") && return lhs == rhs
   relation === Symbol("!=") && return lhs != rhs
   relation === Symbol("<=") && return lhs <= rhs

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1,23 +1,27 @@
 """
     AbstractConstraint
 
-Supertype for the binary feasibility constraints understood by
+Supertype for conditions over a binary vector `x` (entries in `{0, 1}`)
+addressed by 1-based site indices.
+These are the binary feasibility constraints understood by
 [`is_feasible`](@ref).
 
-Concrete subtypes are [`SumConstraint`](@ref), [`NotEqualsConstraint`](@ref),
-[`ExactlyOneConstraint`](@ref), and [`RelationConstraint`](@ref). Each describes
-a condition over a binary vector `x` (entries in `{0, 1}`) addressed by 1-based
-site indices.
+See also [`SumConstraint`](@ref), [`NotEqualsConstraint`](@ref),
+[`ExactlyOneConstraint`](@ref), and [`RelationConstraint`](@ref).
 """
 abstract type AbstractConstraint end
 
 """
     SumConstraint{T} <: AbstractConstraint
+    SumConstraint(sites, weights, relation, rhs)
+    SumConstraint(sites, weights, rhs; relation)
 
-Weighted-sum constraint `sum(weights .* x[sites]) <relation> rhs` over a binary
-vector `x`, where `relation` is one of `:(==)`, `:(!=)`, `:(<)`, `:(<=)`,
-`:(>)`, `:(>=)`. Sites must be unique positive integers and weights nonnegative.
-Build instances with [`sum_constraint`](@ref).
+Weighted-sum constraint over a binary vector `x`:
+`sum(weights[i] * x[sites[i]] for i in eachindex(sites)) relation rhs`.
+
+`sites` must be unique positive integers, `weights` must be nonnegative and the
+same length as `sites`, and `relation` must be one of `:(==)`, `:(!=)`,
+`:(<=)`, or `:(>=)`.
 """
 struct SumConstraint{T<:Real} <: AbstractConstraint
   sites::Vector{Int}
@@ -50,12 +54,20 @@ function SumConstraint(sites, weights, relation, rhs)
   return SumConstraint{T}(sites, weight_vec, relation, rhs_value)
 end
 
+function SumConstraint(sites, weights, rhs; relation)
+  return SumConstraint(sites, weights, relation, rhs)
+end
+
 """
     NotEqualsConstraint <: AbstractConstraint
+    NotEqualsConstraint(sites, values)
 
-Excludes a single assignment: `x[sites]` must differ from `values` in at least
-one position, i.e. the exact partial assignment `x[sites] == values` is
-forbidden. Build instances with [`not_equals_constraint`](@ref).
+Excludes a single assignment over a binary vector `x`: at least one component of
+`x[sites]` must differ from `values`. Equivalently, the partial assignment
+`x[sites] == values` is forbidden.
+
+`sites` must be unique positive integers, and `values` must contain only binary
+values (`0` or `1`) with the same length as `sites`.
 """
 struct NotEqualsConstraint <: AbstractConstraint
   sites::Vector{Int}
@@ -72,9 +84,10 @@ end
 
 """
     ExactlyOneConstraint <: AbstractConstraint
+    ExactlyOneConstraint(sites)
 
-Requires exactly one of `x[sites]` to equal `1`. Build instances with
-[`exactly_one_constraint`](@ref).
+Requires `sum(x[site] for site in sites) == 1` over a binary vector `x`.
+`sites` must be unique positive integers.
 """
 struct ExactlyOneConstraint <: AbstractConstraint
   sites::Vector{Int}
@@ -86,10 +99,13 @@ end
 
 """
     RelationConstraint <: AbstractConstraint
+    RelationConstraint(left_site, relation, right_site)
 
-Pairwise constraint `x[left_site] <relation> x[right_site]` between two distinct
-sites, where `relation` is one of `:(==)`, `:(!=)`, `:(<)`, `:(<=)`, `:(>)`,
-`:(>=)`. Build instances with [`relation_constraint`](@ref).
+Pairwise constraint over a binary vector `x`:
+`x[left_site] relation x[right_site]`.
+
+`left_site` and `right_site` must be distinct positive integers, and `relation`
+must be one of `:(==)`, `:(!=)`, `:(<=)`, or `:(>=)`.
 """
 struct RelationConstraint <: AbstractConstraint
   left_site::Int
@@ -106,72 +122,12 @@ struct RelationConstraint <: AbstractConstraint
 end
 
 """
-    sum_constraint(sites, weights, relation, rhs)
-    sum_constraint(sites, weights, rhs; relation = :(==))
-
-Construct a [`SumConstraint`](@ref) `sum(weights .* x[sites]) <relation> rhs`.
-
-Two call forms are supported. In the four-argument form the relation is the
-third positional argument. In the three-argument form `rhs` is the third
-positional argument and the relation is the `relation` keyword (default
-`:(==)`); passing a relation positionally to this form is an error rather than a
-silently misinterpreted `rhs`.
-
-`sites` must be unique positive integers, `weights` nonnegative and the same
-length as `sites`, and `relation` one of `:(==)`, `:(!=)`, `:(<)`, `:(<=)`,
-`:(>)`, `:(>=)`.
-
-```julia
-sum_constraint([1, 2, 3], [2, 1, 1], :(<=), 3)
-sum_constraint([1, 2], [1, 1], 1)            # relation defaults to :(==)
-```
-"""
-sum_constraint(sites, weights, relation, rhs) = SumConstraint(sites, weights, relation, rhs)
-
-function sum_constraint(sites, weights, rhs; relation=Symbol("=="))
-  rhs isa Symbol && throw(ArgumentError(
-    "sum_constraint(sites, weights, rhs; relation) takes `rhs` as the third " *
-    "positional argument and `relation` as a keyword. To pass a relation " *
-    "positionally, use the four-argument form " *
-    "sum_constraint(sites, weights, relation, rhs).",
-  ))
-
-  return SumConstraint(sites, weights, relation, rhs)
-end
-
-"""
-    not_equals_constraint(sites, values)
-
-Construct a [`NotEqualsConstraint`](@ref) forbidding `x[sites] == values`.
-`values` must be binary (`0` or `1`) and the same length as `sites`.
-"""
-not_equals_constraint(sites, values) = NotEqualsConstraint(sites, values)
-
-"""
-    exactly_one_constraint(sites)
-
-Construct an [`ExactlyOneConstraint`](@ref) requiring exactly one of `x[sites]`
-to equal `1`.
-"""
-exactly_one_constraint(sites) = ExactlyOneConstraint(sites)
-
-"""
-    relation_constraint(left_site, relation, right_site)
-
-Construct a [`RelationConstraint`](@ref)
-`x[left_site] <relation> x[right_site]`. The two sites must be distinct positive
-integers and `relation` one of `:(==)`, `:(!=)`, `:(<)`, `:(<=)`, `:(>)`,
-`:(>=)`.
-"""
-relation_constraint(left_site, relation, right_site) = RelationConstraint(left_site, relation, right_site)
-
-"""
     is_feasible(x, constraint)
     is_feasible(x, constraints)
 
 Test whether the binary vector `x` (entries in `{0, 1}`, 1-based indexing)
 satisfies a single `constraint <: AbstractConstraint` or every constraint in a
-vector `constraints`. An empty constraint vector is feasible.
+vector `constraints`. Any vector is feasible for an empty constraint vector.
 
 Throws an `ArgumentError` if `x` contains a non-binary entry and a `BoundsError`
 if a constraint references a site outside `x`.
@@ -210,9 +166,7 @@ end
 const _VALID_RELATIONS = (
   Symbol("=="),
   Symbol("!="),
-  Symbol("<"),
   Symbol("<="),
-  Symbol(">"),
   Symbol(">="),
 )
 
@@ -284,9 +238,7 @@ end
 function _relation_holds(lhs, relation, rhs)
   relation === Symbol("==") && return lhs == rhs
   relation === Symbol("!=") && return lhs != rhs
-  relation === Symbol("<") && return lhs < rhs
   relation === Symbol("<=") && return lhs <= rhs
-  relation === Symbol(">") && return lhs > rhs
   relation === Symbol(">=") && return lhs >= rhs
 
   error("unsupported relation: $relation")

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -122,12 +122,10 @@ struct RelationConstraint <: AbstractConstraint
 end
 
 """
-    is_feasible(x, constraint)
-    is_feasible(x, constraints)
+    is_feasible(x, constraint::AbstractConstraint)
 
 Test whether the binary vector `x` (entries in `{0, 1}`, 1-based indexing)
-satisfies a single `constraint <: AbstractConstraint` or every constraint in a
-vector `constraints`. Any vector is feasible for an empty constraint vector.
+satisfies a single `constraint <: AbstractConstraint`.
 
 Throws an `ArgumentError` if `x` contains a non-binary entry and a `BoundsError`
 if a constraint references a site outside `x`.
@@ -159,6 +157,16 @@ function is_feasible(x::AbstractVector, constraint::RelationConstraint)
   return _relation_holds(lhs, constraint.relation, rhs)
 end
 
+"""
+    is_feasible(x, constraints::Vector{AbstractConstraint})
+
+Test whether the binary vector `x`
+satisfies every constraint in a vector `constraints`.
+Any vector is feasible for an empty constraint vector.
+
+Throws an `ArgumentError` if `x` contains a non-binary entry and a `BoundsError`
+if a constraint references a site outside `x`.
+"""
 function is_feasible(x::AbstractVector, constraints::AbstractVector{<:AbstractConstraint})
   return all(constraint -> is_feasible(x, constraint), constraints)
 end

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -42,6 +42,9 @@
     @test_throws ArgumentError sum_constraint([1], [-1], Symbol("=="), 0)
     @test_throws ArgumentError sum_constraint([1], [1], Symbol("~"), 0)
     @test_throws ArgumentError sum_constraint([1], [1], "==", 0)
+    # A relation passed positionally to the three-argument form is rejected
+    # rather than silently treated as `rhs`.
+    @test_throws ArgumentError sum_constraint([1, 2], [1, 1], Symbol("<="))
 
     @test_throws DimensionMismatch not_equals_constraint([1, 2], [1])
     @test_throws ArgumentError not_equals_constraint([1], [2])

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -1,0 +1,87 @@
+@testset "Constraints" begin
+  @testset "Constructors" begin
+    sum = sum_constraint([1, 3], [2, 1], Symbol("<="), 2)
+    @test sum isa SumConstraint
+    @test sum isa AbstractConstraint
+    @test sum.sites == [1, 3]
+    @test sum.weights == [2, 1]
+    @test sum.relation == Symbol("<=")
+    @test sum.rhs == 2
+
+    default_sum = sum_constraint([1, 2], [1.5, 0.5], 2.0)
+    @test default_sum.relation == Symbol("==")
+    @test default_sum.weights == [1.5, 0.5]
+    @test default_sum.rhs == 2.0
+
+    not_equals = not_equals_constraint([1, 2], [1, 0])
+    @test not_equals isa NotEqualsConstraint
+    @test not_equals isa AbstractConstraint
+    @test not_equals.sites == [1, 2]
+    @test not_equals.values == [1, 0]
+
+    exactly_one = exactly_one_constraint(2:4)
+    @test exactly_one isa ExactlyOneConstraint
+    @test exactly_one isa AbstractConstraint
+    @test exactly_one.sites == [2, 3, 4]
+
+    relation = relation_constraint(1, Symbol(">="), 2)
+    @test relation isa RelationConstraint
+    @test relation isa AbstractConstraint
+    @test relation.left_site == 1
+    @test relation.relation == Symbol(">=")
+    @test relation.right_site == 2
+  end
+
+  @testset "Constructor validation" begin
+    @test_throws ArgumentError exactly_one_constraint(Int[])
+    @test_throws ArgumentError exactly_one_constraint([0])
+    @test_throws ArgumentError exactly_one_constraint([1, 1])
+    @test_throws ArgumentError exactly_one_constraint([1.0])
+
+    @test_throws DimensionMismatch sum_constraint([1, 2], [1], Symbol("=="), 1)
+    @test_throws ArgumentError sum_constraint([1], [-1], Symbol("=="), 0)
+    @test_throws ArgumentError sum_constraint([1], [1], Symbol("~"), 0)
+    @test_throws ArgumentError sum_constraint([1], [1], "==", 0)
+
+    @test_throws DimensionMismatch not_equals_constraint([1, 2], [1])
+    @test_throws ArgumentError not_equals_constraint([1], [2])
+
+    @test_throws ArgumentError relation_constraint(0, Symbol("=="), 1)
+    @test_throws ArgumentError relation_constraint(1, Symbol("=="), 1)
+    @test_throws ArgumentError relation_constraint(1, Symbol("~"), 2)
+    @test_throws ArgumentError relation_constraint(1, "==", 2)
+  end
+
+  @testset "Feasibility" begin
+    sum_le = sum_constraint([1, 2, 3], [2, 1, 1], Symbol("<="), 3)
+    @test is_feasible([1, 0, 1], sum_le)
+    @test !is_feasible([1, 1, 1], sum_le)
+
+    sum_eq = sum_constraint([1, 2], [1, 1], 1)
+    @test is_feasible([1, 0], sum_eq)
+    @test !is_feasible([1, 1], sum_eq)
+
+    not_equals = not_equals_constraint([1, 3], [1, 0])
+    @test !is_feasible([1, 1, 0], not_equals)
+    @test is_feasible([1, 1, 1], not_equals)
+
+    exactly_one = exactly_one_constraint([2, 3, 4])
+    @test is_feasible([0, 1, 0, 0], exactly_one)
+    @test !is_feasible([0, 1, 1, 0], exactly_one)
+
+    relation = relation_constraint(1, Symbol("<="), 2)
+    @test is_feasible([0, 1], relation)
+    @test !is_feasible([1, 0], relation)
+
+    constraints = AbstractConstraint[
+      sum_constraint([1, 2], [1, 1], 1),
+      relation_constraint(1, Symbol(">="), 2),
+    ]
+    @test is_feasible([1, 0], constraints)
+    @test !is_feasible([0, 1], constraints)
+    @test is_feasible([1, 0], AbstractConstraint[])
+
+    @test_throws ArgumentError is_feasible([0, 2], exactly_one)
+    @test_throws BoundsError is_feasible([1], relation_constraint(1, Symbol("=="), 2))
+  end
+end

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -1,6 +1,6 @@
 @testset "Constraints" begin
   @testset "Constructors" begin
-    sum = sum_constraint([1, 3], [2, 1], Symbol("<="), 2)
+    sum = SumConstraint([1, 3], [2, 1], Symbol("<="), 2)
     @test sum isa SumConstraint
     @test sum isa AbstractConstraint
     @test sum.sites == [1, 3]
@@ -8,23 +8,23 @@
     @test sum.relation == Symbol("<=")
     @test sum.rhs == 2
 
-    default_sum = sum_constraint([1, 2], [1.5, 0.5], 2.0)
-    @test default_sum.relation == Symbol("==")
-    @test default_sum.weights == [1.5, 0.5]
-    @test default_sum.rhs == 2.0
+    keyword_sum = SumConstraint([1, 2], [1.5, 0.5], 2.0; relation=Symbol("=="))
+    @test keyword_sum.relation == Symbol("==")
+    @test keyword_sum.weights == [1.5, 0.5]
+    @test keyword_sum.rhs == 2.0
 
-    not_equals = not_equals_constraint([1, 2], [1, 0])
+    not_equals = NotEqualsConstraint([1, 2], [1, 0])
     @test not_equals isa NotEqualsConstraint
     @test not_equals isa AbstractConstraint
     @test not_equals.sites == [1, 2]
     @test not_equals.values == [1, 0]
 
-    exactly_one = exactly_one_constraint(2:4)
+    exactly_one = ExactlyOneConstraint(2:4)
     @test exactly_one isa ExactlyOneConstraint
     @test exactly_one isa AbstractConstraint
     @test exactly_one.sites == [2, 3, 4]
 
-    relation = relation_constraint(1, Symbol(">="), 2)
+    relation = RelationConstraint(1, Symbol(">="), 2)
     @test relation isa RelationConstraint
     @test relation isa AbstractConstraint
     @test relation.left_site == 1
@@ -33,58 +33,58 @@
   end
 
   @testset "Constructor validation" begin
-    @test_throws ArgumentError exactly_one_constraint(Int[])
-    @test_throws ArgumentError exactly_one_constraint([0])
-    @test_throws ArgumentError exactly_one_constraint([1, 1])
-    @test_throws ArgumentError exactly_one_constraint([1.0])
+    @test_throws ArgumentError ExactlyOneConstraint(Int[])
+    @test_throws ArgumentError ExactlyOneConstraint([0])
+    @test_throws ArgumentError ExactlyOneConstraint([1, 1])
+    @test_throws ArgumentError ExactlyOneConstraint([1.0])
 
-    @test_throws DimensionMismatch sum_constraint([1, 2], [1], Symbol("=="), 1)
-    @test_throws ArgumentError sum_constraint([1], [-1], Symbol("=="), 0)
-    @test_throws ArgumentError sum_constraint([1], [1], Symbol("~"), 0)
-    @test_throws ArgumentError sum_constraint([1], [1], "==", 0)
-    # A relation passed positionally to the three-argument form is rejected
-    # rather than silently treated as `rhs`.
-    @test_throws ArgumentError sum_constraint([1, 2], [1, 1], Symbol("<="))
+    @test_throws DimensionMismatch SumConstraint([1, 2], [1], Symbol("=="), 1)
+    @test_throws ArgumentError SumConstraint([1], [-1], Symbol("=="), 0)
+    @test_throws ArgumentError SumConstraint([1], [1], Symbol("~"), 0)
+    @test_throws ArgumentError SumConstraint([1], [1], Symbol("<"), 0)
+    @test_throws ArgumentError SumConstraint([1], [1], "==", 0)
+    @test_throws UndefKeywordError SumConstraint([1, 2], [1, 1], 1)
 
-    @test_throws DimensionMismatch not_equals_constraint([1, 2], [1])
-    @test_throws ArgumentError not_equals_constraint([1], [2])
+    @test_throws DimensionMismatch NotEqualsConstraint([1, 2], [1])
+    @test_throws ArgumentError NotEqualsConstraint([1], [2])
 
-    @test_throws ArgumentError relation_constraint(0, Symbol("=="), 1)
-    @test_throws ArgumentError relation_constraint(1, Symbol("=="), 1)
-    @test_throws ArgumentError relation_constraint(1, Symbol("~"), 2)
-    @test_throws ArgumentError relation_constraint(1, "==", 2)
+    @test_throws ArgumentError RelationConstraint(0, Symbol("=="), 1)
+    @test_throws ArgumentError RelationConstraint(1, Symbol("=="), 1)
+    @test_throws ArgumentError RelationConstraint(1, Symbol("~"), 2)
+    @test_throws ArgumentError RelationConstraint(1, Symbol(">"), 2)
+    @test_throws ArgumentError RelationConstraint(1, "==", 2)
   end
 
   @testset "Feasibility" begin
-    sum_le = sum_constraint([1, 2, 3], [2, 1, 1], Symbol("<="), 3)
+    sum_le = SumConstraint([1, 2, 3], [2, 1, 1], Symbol("<="), 3)
     @test is_feasible([1, 0, 1], sum_le)
     @test !is_feasible([1, 1, 1], sum_le)
 
-    sum_eq = sum_constraint([1, 2], [1, 1], 1)
+    sum_eq = SumConstraint([1, 2], [1, 1], 1; relation=Symbol("=="))
     @test is_feasible([1, 0], sum_eq)
     @test !is_feasible([1, 1], sum_eq)
 
-    not_equals = not_equals_constraint([1, 3], [1, 0])
+    not_equals = NotEqualsConstraint([1, 3], [1, 0])
     @test !is_feasible([1, 1, 0], not_equals)
     @test is_feasible([1, 1, 1], not_equals)
 
-    exactly_one = exactly_one_constraint([2, 3, 4])
+    exactly_one = ExactlyOneConstraint([2, 3, 4])
     @test is_feasible([0, 1, 0, 0], exactly_one)
     @test !is_feasible([0, 1, 1, 0], exactly_one)
 
-    relation = relation_constraint(1, Symbol("<="), 2)
+    relation = RelationConstraint(1, Symbol("<="), 2)
     @test is_feasible([0, 1], relation)
     @test !is_feasible([1, 0], relation)
 
     constraints = AbstractConstraint[
-      sum_constraint([1, 2], [1, 1], 1),
-      relation_constraint(1, Symbol(">="), 2),
+      SumConstraint([1, 2], [1, 1], 1; relation=Symbol("==")),
+      RelationConstraint(1, Symbol(">="), 2),
     ]
     @test is_feasible([1, 0], constraints)
     @test !is_feasible([0, 1], constraints)
     @test is_feasible([1, 0], AbstractConstraint[])
 
     @test_throws ArgumentError is_feasible([0, 2], exactly_one)
-    @test_throws BoundsError is_feasible([1], relation_constraint(1, Symbol("=="), 2))
+    @test_throws BoundsError is_feasible([1], RelationConstraint(1, Symbol("=="), 2))
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,9 @@ include(filepath("backend.jl"))
 # Ising <-> QUBO utilities
 include(filepath("ising_conversion.jl"))
 
+# Binary constraint API
+include(filepath("constraints.jl"))
+
 # Traditional interface
 include(filepath("qubo.jl"))
 include(filepath("pubo.jl"))


### PR DESCRIPTION
## Summary

- Adds public binary constraint types for weighted sums, not-equals assignment exclusions, exactly-one constraints, and pairwise relation constraints.
- Adds ergonomic constructors with validation for sites, vector lengths, relation symbols, nonnegative weights, and binary values.
- Adds `is_feasible(x, constraint)` and `is_feasible(x, constraints)` for single constraints and vectors of constraints.

Closes #56.

## Tests

- `julia --project=. -e 'using Test, TenSolver; include("test/constraints.jl")'` passed.
- `julia --project=. -e 'using Pkg; Pkg.test(; test_args=["constraints"])'` passed. The repo test harness does not consume `test_args`, so this ran the full package suite.

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `b238204a0390ba3df218e4e52e8deaf8fa7f0ef2`
- Stacked status: not stacked; based directly on `main`
- Prerequisite PRs: none
