### PR TITLE
Add native projection-MPO assembly utilities

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -63,6 +63,7 @@ They are documented here for advanced users who may need to understand the inter
 
 ```@docs
 TenSolver.tensorize
+TenSolver.SparseTensorEntry
 TenSolver.itensor_from_nonzeros
 TenSolver.projection_mpo
 TenSolver.projection_mpos

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -47,6 +47,7 @@ TenSolver.NotEqualsConstraint
 TenSolver.ExactlyOneConstraint
 TenSolver.RelationConstraint
 TenSolver.is_feasible
+TenSolver.constraint_sites
 ```
 
 ## Utility Functions

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -62,6 +62,9 @@ They are documented here for advanced users who may need to understand the inter
 
 ```@docs
 TenSolver.tensorize
+TenSolver.itensor_from_nonzeros
+TenSolver.projection_mpo
+TenSolver.projection_mpos
 TenSolver.qmatrix_permutation
 TenSolver.preprocess_qubo
 ```

--- a/src/TenSolver.jl
+++ b/src/TenSolver.jl
@@ -20,6 +20,8 @@ export AbstractConstraint
 export SumConstraint, NotEqualsConstraint, ExactlyOneConstraint, RelationConstraint
 export is_feasible
 
+include("projection_mpo.jl")
+
 include("solver.jl")
 export minimize, maximize
 export DMRGBackend

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -171,6 +171,29 @@ function is_feasible(x::AbstractVector, constraints::AbstractVector{<:AbstractCo
   return all(constraint -> is_feasible(x, constraint), constraints)
 end
 
+"""
+    constraint_sites(constraint::AbstractConstraint)
+
+Access the site indices stored in the `constraint`.
+"""
+function constraint_sites end
+
+function constraint_sites(constraint::SumConstraint)
+  return constraint.sites
+end
+
+function constraint_sites(constraint::NotEqualsConstraint)
+  return constraint.sites
+end
+
+function constraint_sites(constraint::ExactlyOneConstraint)
+  return constraint.sites
+end
+
+function constraint_sites(constraint::RelationConstraint)
+  return [constraint.left_site, constraint.right_site]
+end
+
 
 #----------------------------------------------------------#
 # Constraint Validation

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -1,5 +1,6 @@
 # Projection-MPO construction adapted from the CoTenN constraint projection
-# design, but implemented natively with ITensors/ITensorMPS.
+# design in Sharma, Ritvik, Cheng Peng, Siddharth Dangwal, and Sara Achour,
+# "CoTenN: Constrained Optimization with Tensor Networks," PLDI 2026.
 
 struct _SparseTensorEntry{T}
   coordinates::Dict{Int,Int}
@@ -38,6 +39,10 @@ function _identity_tensor(::Type{T}, site) where {T}
 end
 
 function _pass_through_tensor(::Type{T}, site, left_link, right_link) where {T}
+  if isnothing(left_link) && isnothing(right_link)
+    return _identity_tensor(T, site)
+  end
+
   inds = _mpo_tensor_indices(site, left_link, right_link)
   path_count = _path_count(left_link, right_link)
   nonzeros = Tuple{Vector{Int},T}[]
@@ -94,6 +99,11 @@ function _tensor_to_mpo(::Type{T}, entries, sites) where {T}
     site = site_vec[site_position]
     left_link = site_position == firstindex(site_vec) ? nothing : links[site_position - 1]
     right_link = site_position == lastindex(site_vec) ? nothing : links[site_position]
+    if !isempty(entry_vec) && all(entry -> !haskey(entry.coordinates, site_position), entry_vec)
+      tensors[site_position] = _pass_through_tensor(T, site, left_link, right_link)
+      continue
+    end
+
     inds = _mpo_tensor_indices(site, left_link, right_link)
     nonzeros = Tuple{Vector{Int},T}[]
 

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -151,21 +151,6 @@ function constraint_sites(constraint::RelationConstraint)
   return [constraint.left_site, constraint.right_site]
 end
 
-function projection_entries(::Type{T}, constraint::SumConstraint) where {T}
-  return projection_entries(T, constraint, constraint_sites(constraint))
-end
-
-function projection_entries(::Type{T}, constraint::NotEqualsConstraint) where {T}
-  return projection_entries(T, constraint, constraint_sites(constraint))
-end
-
-function projection_entries(::Type{T}, constraint::ExactlyOneConstraint) where {T}
-  return projection_entries(T, constraint, constraint_sites(constraint))
-end
-
-function projection_entries(::Type{T}, constraint::RelationConstraint) where {T}
-  return projection_entries(T, constraint, constraint_sites(constraint))
-end
 
 function projection_entries(::Type{T}, constraint::AbstractConstraint, constraint_sites) where {T}
   assignments = Iterators.product(fill(0:1, length(constraint_sites))...)
@@ -194,22 +179,6 @@ end
 Build a diagonal projection MPO that preserves basis states satisfying
 `constraint` and zeros infeasible states.
 """
-function projection_mpo(::Type{T}, constraint::SumConstraint, sites) where {T}
-  return projection_mpo(T, constraint, constraint_sites(constraint), sites)
-end
-
-function projection_mpo(::Type{T}, constraint::NotEqualsConstraint, sites) where {T}
-  return projection_mpo(T, constraint, constraint_sites(constraint), sites)
-end
-
-function projection_mpo(::Type{T}, constraint::ExactlyOneConstraint, sites) where {T}
-  return projection_mpo(T, constraint, constraint_sites(constraint), sites)
-end
-
-function projection_mpo(::Type{T}, constraint::RelationConstraint, sites) where {T}
-  return projection_mpo(T, constraint, constraint_sites(constraint), sites)
-end
-
 function projection_mpo(::Type{T}, constraint::AbstractConstraint, constraint_sites, sites) where {T}
   site_vec = collect(sites)
   all(site -> 1 <= site <= length(site_vec), constraint_sites) ||
@@ -218,16 +187,7 @@ function projection_mpo(::Type{T}, constraint::AbstractConstraint, constraint_si
   return tensor_to_mpo(T, projection_entries(T, constraint), site_vec)
 end
 
-projection_mpo(constraint::SumConstraint, sites) =
-  projection_mpo(Float64, constraint, sites)
-
-projection_mpo(constraint::NotEqualsConstraint, sites) =
-  projection_mpo(Float64, constraint, sites)
-
-projection_mpo(constraint::ExactlyOneConstraint, sites) =
-  projection_mpo(Float64, constraint, sites)
-
-projection_mpo(constraint::RelationConstraint, sites) =
+projection_mpo(constraint::AbstractConstraint, sites) =
   projection_mpo(Float64, constraint, sites)
 
 """

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -1,6 +1,17 @@
 # Projection-MPO construction adapted from the CoTenN constraint projection
 # design in Sharma, Ritvik, Cheng Peng, Siddharth Dangwal, and Sara Achour,
 # "CoTenN: Constrained Optimization with Tensor Networks," PLDI 2026.
+#
+# Note on ITensors.jl / ITensorMPS.jl helpers: the on-site identity is built with
+# `ITensors.delta` rather than a hand-rolled Kronecker tensor. The higher-level
+# `OpSum`/`MPO(::OpSum, sites)` (AutoMPO) machinery was considered for the full
+# assembly but is intentionally not used here: it heuristically compresses the
+# operator and does not guarantee the exact, uncompressed one-path-per-feasible-
+# assignment structure this module needs (bond dimension = number of feasible
+# assignments). Bounding/compressing that bond dimension is deferred to #58, where
+# projections meet solves and the downstream cost is measurable. The remaining
+# path-threaded tensors have no direct high-level equivalent, so they are assembled
+# from sparse nonzeros via `itensor_from_nonzeros`.
 
 """
     SparseTensorEntry{T}
@@ -39,11 +50,10 @@ end
 
 itensor_from_nonzeros(inds, nonzeros) = itensor_from_nonzeros(Float64, inds, nonzeros)
 
+# Diagonal identity over a single physical site (`sum_s |s><s|`). This is exactly
+# what `ITensors.delta` builds, so we reuse it instead of assembling by hand.
 function identity_tensor(::Type{T}, site) where {T}
-  site_prime = ITensors.prime(site)
-  nonzeros = (((state, state), one(T)) for state in 1:ITensors.dim(site))
-
-  return itensor_from_nonzeros(T, (site, site_prime), nonzeros)
+  return ITensors.delta(T, site, ITensors.prime(site))
 end
 
 function pass_through_tensor(::Type{T}, site, left_link, right_link) where {T}
@@ -105,6 +115,16 @@ function tensor_to_mpo(::Type{T}, entries, sites) where {T}
     for i in 1:(length(site_vec) - 1)
   ]
 
+  # Each entry's `value` is written exactly once, at the first register site the
+  # entry constrains. Anchoring on the first *constrained* site (rather than the
+  # first register site) keeps the coefficient from being dropped when the leading
+  # sites are pass-through, where the tensor is built without consulting `value`.
+  # Entries that constrain no site fall back to the first register site.
+  value_positions = [
+    isempty(entry.coordinates) ? firstindex(site_vec) : minimum(keys(entry.coordinates))
+    for entry in entry_vec
+  ]
+
   tensors = Vector{ITensors.ITensor}(undef, length(site_vec))
   for site_position in eachindex(site_vec)
     site = site_vec[site_position]
@@ -121,7 +141,7 @@ function tensor_to_mpo(::Type{T}, entries, sites) where {T}
     for (path, entry) in enumerate(entry_vec)
       states = get(entry.coordinates, site_position, nothing)
       states = isnothing(states) ? (1, 2) : (states,)
-      coefficient = site_position == firstindex(site_vec) ? entry.value : one(T)
+      coefficient = site_position == value_positions[path] ? entry.value : one(T)
 
       for state in states
         push!(nonzeros, (mpo_coordinate(state, path, left_link, right_link), coefficient))

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -50,15 +50,9 @@ end
 
 itensor_from_nonzeros(inds, nonzeros) = itensor_from_nonzeros(Float64, inds, nonzeros)
 
-# Diagonal identity over a single physical site (`sum_s |s><s|`). This is exactly
-# what `ITensors.delta` builds, so we reuse it instead of assembling by hand.
-function identity_tensor(::Type{T}, site) where {T}
-  return ITensors.delta(T, site, ITensors.prime(site))
-end
-
 function pass_through_tensor(::Type{T}, site, left_link, right_link) where {T}
   if isnothing(left_link) && isnothing(right_link)
-    return identity_tensor(T, site)
+    return ITensors.delta(T, site, ITensors.prime(site))
   end
 
   inds = mpo_tensor_indices(site, left_link, right_link)
@@ -73,28 +67,63 @@ function pass_through_tensor(::Type{T}, site, left_link, right_link) where {T}
 end
 
 function path_count(left_link, right_link)
-  !isnothing(left_link) && return ITensors.dim(left_link)
-  !isnothing(right_link) && return ITensors.dim(right_link)
-
-  return 1
+  if !isnothing(left_link)          # All but first index
+    return ITensors.dim(left_link)
+  elseif !isnothing(right_link)     # First index
+    return ITensors.dim(right_link)
+  else                              # 1-qubit case
+    return 1
+  end
 end
 
 function mpo_tensor_indices(site, left_link, right_link)
-  inds = []
-  !isnothing(left_link) && push!(inds, left_link)
-  push!(inds, site, ITensors.prime(site))
-  !isnothing(right_link) && push!(inds, right_link)
-
-  return Tuple(inds)
+  return filter(!isnothing, (left_link, site, ITensors.prime(site), right_link))
 end
 
 function mpo_coordinate(state::Integer, path::Integer, left_link, right_link)
-  coordinate = Int[]
-  !isnothing(left_link) && push!(coordinate, path)
-  push!(coordinate, state, state)
-  !isnothing(right_link) && push!(coordinate, path)
+  return filter(!isnothing, [ifnotnothing(left_link, path), state, state, ifnotnothing(right_link, path)])
+end
 
-  return coordinate
+function first_constrained_site(entry, default_site)
+  return isempty(entry.coordinates) ? default_site : minimum(keys(entry.coordinates))
+end
+
+function site_is_unconstrained(entries, site_position)
+  return !isempty(entries) && !any(entry -> haskey(entry.coordinates, site_position), entries)
+end
+
+function site_link(links, link_position)
+  return 1 <= link_position <= length(links) ? links[link_position] : nothing
+end
+
+function site_states(entry::SparseTensorEntry, site_position)
+  state = get(entry.coordinates, site_position, (1, 2))
+  return Tuple(state)
+end
+
+function site_coefficient(::Type{T}, entry, site_position, value_site) where {T}
+  return site_position == value_site ? entry.value : one(T)
+end
+
+function projection_site_nonzeros(::Type{T}, entries, left_link, right_link, site_position, value_positions) where {T}
+  return [
+    (mpo_coordinate(state, path, left_link, right_link),
+     site_coefficient(T, entry, site_position, value_positions[path]))
+    for (path, entry) in enumerate(entries)
+    for state in site_states(entry, site_position)
+  ]
+end
+
+function projection_site_tensor(::Type{T}, site, left_link, right_link, entries, site_position, value_positions) where {T}
+  if site_is_unconstrained(entries, site_position)
+    return pass_through_tensor(T, site, left_link, right_link)
+  else
+    return itensor_from_nonzeros(
+      T,
+      mpo_tensor_indices(site, left_link, right_link),
+      projection_site_nonzeros(T, entries, left_link, right_link, site_position, value_positions),
+    )
+  end
 end
 
 function tensor_to_mpo(::Type{T}, entries, sites) where {T}
@@ -106,53 +135,30 @@ function tensor_to_mpo(::Type{T}, entries, sites) where {T}
   entry_vec = collect(entries)
   validate_sparse_entries(entry_vec, site_vec)
 
-  # Each feasible partial assignment gets one path threaded through the MPO
-  # links. Constrained sites write that assignment; unconstrained sites pass the
-  # path and physical basis state through unchanged.
   num_paths = max(length(entry_vec), 1)
-  links = [
-    ITensors.Index(num_paths, "Link,Projection,l=$i")
-    for i in 1:(length(site_vec) - 1)
-  ]
+  links = [ITensors.Index(num_paths, "Link,Projection,l=$i")
+           for i in 1:max(length(site_vec) - 1, 0)
+          ]
 
-  # Each entry's `value` is written exactly once, at the first register site the
-  # entry constrains. Anchoring on the first *constrained* site (rather than the
-  # first register site) keeps the coefficient from being dropped when the leading
-  # sites are pass-through, where the tensor is built without consulting `value`.
-  # Entries that constrain no site fall back to the first register site.
-  value_positions = [
-    isempty(entry.coordinates) ? firstindex(site_vec) : minimum(keys(entry.coordinates))
-    for entry in entry_vec
-  ]
+  # Each feasible partial assignment gets one path threaded through the MPO links.
+  # Constrained sites write that assignment;
+  # unconstrained sites pass the path and physical basis state through unchanged.
+  value_positions = map(entry -> first_constrained_site(entry, firstindex(site_vec)), entry_vec)
 
-  tensors = Vector{ITensors.ITensor}(undef, length(site_vec))
-  for site_position in eachindex(site_vec)
-    site = site_vec[site_position]
-    left_link = site_position == firstindex(site_vec) ? nothing : links[site_position - 1]
-    right_link = site_position == lastindex(site_vec) ? nothing : links[site_position]
-    if !isempty(entry_vec) && all(entry -> !haskey(entry.coordinates, site_position), entry_vec)
-      tensors[site_position] = pass_through_tensor(T, site, left_link, right_link)
-      continue
-    end
-
-    inds = mpo_tensor_indices(site, left_link, right_link)
-    nonzeros = Tuple{Vector{Int},T}[]
-
-    for (path, entry) in enumerate(entry_vec)
-      states = get(entry.coordinates, site_position, nothing)
-      states = isnothing(states) ? (1, 2) : (states,)
-      coefficient = site_position == value_positions[path] ? entry.value : one(T)
-
-      for state in states
-        push!(nonzeros, (mpo_coordinate(state, path, left_link, right_link), coefficient))
-      end
-    end
-
-    tensors[site_position] = itensor_from_nonzeros(T, inds, nonzeros)
-  end
-
-  return ITensorMPS.MPO(tensors)
+  return ITensorMPS.MPO([
+    projection_site_tensor(
+      T,
+      site_vec[site_position],
+      site_link(links, site_position - 1),
+      site_link(links, site_position),
+      entry_vec,
+      site_position,
+      value_positions,
+    )
+    for site_position in eachindex(site_vec)
+   ])
 end
+
 
 function validate_sparse_entries(entries, sites)
   for entry in entries

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -1,0 +1,196 @@
+# Projection-MPO construction adapted from the CoTenN constraint projection
+# design, but implemented natively with ITensors/ITensorMPS.
+
+struct _SparseTensorEntry{T}
+  coordinates::Dict{Int,Int}
+  value::T
+end
+
+"""
+    itensor_from_nonzeros([T], inds, nonzeros)
+
+Build an `ITensor` over `inds` from sparse `(coordinate, value)` entries.
+Coordinates are 1-based tuples matching `inds`.
+"""
+function itensor_from_nonzeros(::Type{T}, inds, nonzeros) where {T}
+  ind_tuple = Tuple(inds)
+  tensor = ITensors.ITensor(T, ind_tuple...)
+
+  for (coordinate, value) in nonzeros
+    coordinate_tuple = Tuple(coordinate)
+    length(coordinate_tuple) == length(ind_tuple) ||
+      throw(DimensionMismatch("nonzero coordinate length must match tensor order"))
+
+    selector = map(i -> ind_tuple[i] => coordinate_tuple[i], eachindex(ind_tuple))
+    tensor[selector...] = tensor[selector...] + convert(T, value)
+  end
+
+  return tensor
+end
+
+itensor_from_nonzeros(inds, nonzeros) = itensor_from_nonzeros(Float64, inds, nonzeros)
+
+function _identity_tensor(::Type{T}, site) where {T}
+  site_prime = ITensors.prime(site)
+  nonzeros = (((state, state), one(T)) for state in 1:ITensors.dim(site))
+
+  return itensor_from_nonzeros(T, (site, site_prime), nonzeros)
+end
+
+function _pass_through_tensor(::Type{T}, site, left_link, right_link) where {T}
+  inds = _mpo_tensor_indices(site, left_link, right_link)
+  path_count = _path_count(left_link, right_link)
+  nonzeros = Tuple{Vector{Int},T}[]
+
+  for path in 1:path_count, state in 1:ITensors.dim(site)
+    push!(nonzeros, (_mpo_coordinate(state, path, left_link, right_link), one(T)))
+  end
+
+  return itensor_from_nonzeros(T, inds, nonzeros)
+end
+
+function _path_count(left_link, right_link)
+  !isnothing(left_link) && return ITensors.dim(left_link)
+  !isnothing(right_link) && return ITensors.dim(right_link)
+
+  return 1
+end
+
+function _mpo_tensor_indices(site, left_link, right_link)
+  inds = []
+  !isnothing(left_link) && push!(inds, left_link)
+  push!(inds, site, ITensors.prime(site))
+  !isnothing(right_link) && push!(inds, right_link)
+
+  return Tuple(inds)
+end
+
+function _mpo_coordinate(state::Integer, path::Integer, left_link, right_link)
+  coordinate = Int[]
+  !isnothing(left_link) && push!(coordinate, path)
+  push!(coordinate, state, state)
+  !isnothing(right_link) && push!(coordinate, path)
+
+  return coordinate
+end
+
+function _tensor_to_mpo(::Type{T}, entries, sites) where {T}
+  site_vec = collect(sites)
+  isempty(site_vec) && throw(ArgumentError("sites must not be empty"))
+  all(site -> ITensors.dim(site) == 2, site_vec) ||
+    throw(ArgumentError("projection MPO sites must be binary Qudit indices"))
+
+  entry_vec = collect(entries)
+  _validate_sparse_entries(entry_vec, site_vec)
+
+  path_count = max(length(entry_vec), 1)
+  links = [
+    ITensors.Index(path_count, "Link,Projection,l=$i")
+    for i in 1:(length(site_vec) - 1)
+  ]
+
+  tensors = Vector{ITensors.ITensor}(undef, length(site_vec))
+  for site_position in eachindex(site_vec)
+    site = site_vec[site_position]
+    left_link = site_position == firstindex(site_vec) ? nothing : links[site_position - 1]
+    right_link = site_position == lastindex(site_vec) ? nothing : links[site_position]
+    inds = _mpo_tensor_indices(site, left_link, right_link)
+    nonzeros = Tuple{Vector{Int},T}[]
+
+    for (path, entry) in enumerate(entry_vec)
+      states = get(entry.coordinates, site_position, nothing)
+      states = isnothing(states) ? (1, 2) : (states,)
+      coefficient = site_position == firstindex(site_vec) ? entry.value : one(T)
+
+      for state in states
+        push!(nonzeros, (_mpo_coordinate(state, path, left_link, right_link), coefficient))
+      end
+    end
+
+    tensors[site_position] = itensor_from_nonzeros(T, inds, nonzeros)
+  end
+
+  return ITensorMPS.MPO(tensors)
+end
+
+function _validate_sparse_entries(entries, sites)
+  for entry in entries
+    for (site_position, coordinate) in entry.coordinates
+      checkbounds(sites, site_position)
+      1 <= coordinate <= ITensors.dim(sites[site_position]) ||
+        throw(BoundsError(1:ITensors.dim(sites[site_position]), coordinate))
+    end
+  end
+
+  return nothing
+end
+
+function _constraint_sites(constraint::SumConstraint)
+  return constraint.sites
+end
+
+function _constraint_sites(constraint::NotEqualsConstraint)
+  return constraint.sites
+end
+
+function _constraint_sites(constraint::ExactlyOneConstraint)
+  return constraint.sites
+end
+
+function _constraint_sites(constraint::RelationConstraint)
+  return [constraint.left_site, constraint.right_site]
+end
+
+function _projection_entries(::Type{T}, constraint::AbstractConstraint) where {T}
+  constraint_sites = _constraint_sites(constraint)
+  assignments = Iterators.product(fill(0:1, length(constraint_sites))...)
+  entries = _SparseTensorEntry{T}[]
+
+  for assignment in assignments
+    x = zeros(Int, maximum(constraint_sites))
+    coordinates = Dict{Int,Int}()
+
+    for (site, bit) in zip(constraint_sites, assignment)
+      x[site] = bit
+      coordinates[site] = bit + 1
+    end
+
+    if is_feasible(x, constraint)
+      push!(entries, _SparseTensorEntry{T}(coordinates, one(T)))
+    end
+  end
+
+  return entries
+end
+
+"""
+    projection_mpo(constraint, sites)
+
+Build a diagonal projection MPO that preserves basis states satisfying
+`constraint` and zeros infeasible states.
+"""
+function projection_mpo(::Type{T}, constraint::AbstractConstraint, sites) where {T}
+  site_vec = collect(sites)
+  constraint_sites = _constraint_sites(constraint)
+  all(site -> 1 <= site <= length(site_vec), constraint_sites) ||
+    throw(BoundsError(site_vec, maximum(constraint_sites)))
+
+  return _tensor_to_mpo(T, _projection_entries(T, constraint), site_vec)
+end
+
+projection_mpo(constraint::AbstractConstraint, sites) =
+  projection_mpo(Float64, constraint, sites)
+
+"""
+    projection_mpos(constraints, sites)
+
+Build one projection MPO per constraint.
+"""
+function projection_mpos(::Type{T}, constraints::AbstractVector{<:AbstractConstraint}, sites) where {T}
+  site_vec = collect(sites)
+
+  return [projection_mpo(T, constraint, site_vec) for constraint in constraints]
+end
+
+projection_mpos(constraints::AbstractVector{<:AbstractConstraint}, sites) =
+  projection_mpos(Float64, constraints, sites)

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -93,7 +93,7 @@ function site_is_unconstrained(entries, site_position)
 end
 
 function site_link(links, link_position)
-  return 1 <= link_position <= length(links) ? links[link_position] : nothing
+  return get(links, link_position, nothing)
 end
 
 function site_states(entry::SparseTensorEntry, site_position)
@@ -105,32 +105,34 @@ function site_coefficient(::Type{T}, entry, site_position, value_site) where {T}
   return site_position == value_site ? entry.value : one(T)
 end
 
-function projection_site_nonzeros(::Type{T}, entries, left_link, right_link, site_position, value_positions) where {T}
-  return [
-    (mpo_coordinate(state, path, left_link, right_link),
-     site_coefficient(T, entry, site_position, value_positions[path]))
-    for (path, entry) in enumerate(entries)
-    for state in site_states(entry, site_position)
-  ]
-end
-
 function projection_site_tensor(::Type{T}, site, left_link, right_link, entries, site_position, value_positions) where {T}
   if site_is_unconstrained(entries, site_position)
     return pass_through_tensor(T, site, left_link, right_link)
   else
+    nonzeros = [
+      (mpo_coordinate(state, path, left_link, right_link),
+       site_coefficient(T, entry, site_position, value_positions[path]))
+      for (path, entry) in enumerate(entries)
+      for state in site_states(entry, site_position)
+    ]
+
     return itensor_from_nonzeros(
       T,
       mpo_tensor_indices(site, left_link, right_link),
-      projection_site_nonzeros(T, entries, left_link, right_link, site_position, value_positions),
+      nonzeros
     )
   end
 end
 
 function tensor_to_mpo(::Type{T}, entries, sites) where {T}
   site_vec = collect(sites)
-  isempty(site_vec) && throw(ArgumentError("sites must not be empty"))
-  all(site -> ITensors.dim(site) == 2, site_vec) ||
+
+  if isempty(site_vec)
+    throw(ArgumentError("sites must not be empty"))
+  end
+  if !all(site -> ITensors.dim(site) == 2, site_vec)
     throw(ArgumentError("projection MPO sites must be binary Qudit indices"))
+  end
 
   entry_vec = collect(entries)
   validate_sparse_entries(entry_vec, site_vec)
@@ -209,12 +211,12 @@ feasible assignment of the constrained sites is represented as one MPO path.
 """
 function projection_mpo(::Type{T}, constraint::AbstractConstraint, sites) where {T}
   cs = constraint_sites(constraint)
-  site_vec = collect(sites)
 
-  all(site -> 1 <= site <= length(site_vec), cs) ||
-    throw(BoundsError(site_vec, maximum(cs)))
+  if !all(site -> 1 <= site <= length(sites), cs)
+    throw(BoundsError(sites, maximum(cs)))
+  end
 
-  return tensor_to_mpo(T, projection_entries(T, constraint), site_vec)
+  return tensor_to_mpo(T, projection_entries(T, constraint), sites)
 end
 
 projection_mpo(constraint::AbstractConstraint, sites) =
@@ -231,9 +233,7 @@ same collected site register for every constraint. `T` controls the numeric
 element type of the assembled MPO tensors.
 """
 function projection_mpos(::Type{T}, constraints::AbstractVector{<:AbstractConstraint}, sites) where {T}
-  site_vec = collect(sites)
-
-  return [projection_mpo(T, constraint, site_vec) for constraint in constraints]
+  return [projection_mpo(T, constraint, sites) for constraint in constraints]
 end
 
 projection_mpos(constraints::AbstractVector{<:AbstractConstraint}, sites) =

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -2,7 +2,7 @@
 # design in Sharma, Ritvik, Cheng Peng, Siddharth Dangwal, and Sara Achour,
 # "CoTenN: Constrained Optimization with Tensor Networks," PLDI 2026.
 
-struct _SparseTensorEntry{T}
+struct SparseTensorEntry{T}
   coordinates::Dict{Int,Int}
   value::T
 end
@@ -31,37 +31,37 @@ end
 
 itensor_from_nonzeros(inds, nonzeros) = itensor_from_nonzeros(Float64, inds, nonzeros)
 
-function _identity_tensor(::Type{T}, site) where {T}
+function identity_tensor(::Type{T}, site) where {T}
   site_prime = ITensors.prime(site)
   nonzeros = (((state, state), one(T)) for state in 1:ITensors.dim(site))
 
   return itensor_from_nonzeros(T, (site, site_prime), nonzeros)
 end
 
-function _pass_through_tensor(::Type{T}, site, left_link, right_link) where {T}
+function pass_through_tensor(::Type{T}, site, left_link, right_link) where {T}
   if isnothing(left_link) && isnothing(right_link)
-    return _identity_tensor(T, site)
+    return identity_tensor(T, site)
   end
 
-  inds = _mpo_tensor_indices(site, left_link, right_link)
-  path_count = _path_count(left_link, right_link)
+  inds = mpo_tensor_indices(site, left_link, right_link)
+  num_paths = path_count(left_link, right_link)
   nonzeros = Tuple{Vector{Int},T}[]
 
-  for path in 1:path_count, state in 1:ITensors.dim(site)
-    push!(nonzeros, (_mpo_coordinate(state, path, left_link, right_link), one(T)))
+  for path in 1:num_paths, state in 1:ITensors.dim(site)
+    push!(nonzeros, (mpo_coordinate(state, path, left_link, right_link), one(T)))
   end
 
   return itensor_from_nonzeros(T, inds, nonzeros)
 end
 
-function _path_count(left_link, right_link)
+function path_count(left_link, right_link)
   !isnothing(left_link) && return ITensors.dim(left_link)
   !isnothing(right_link) && return ITensors.dim(right_link)
 
   return 1
 end
 
-function _mpo_tensor_indices(site, left_link, right_link)
+function mpo_tensor_indices(site, left_link, right_link)
   inds = []
   !isnothing(left_link) && push!(inds, left_link)
   push!(inds, site, ITensors.prime(site))
@@ -70,7 +70,7 @@ function _mpo_tensor_indices(site, left_link, right_link)
   return Tuple(inds)
 end
 
-function _mpo_coordinate(state::Integer, path::Integer, left_link, right_link)
+function mpo_coordinate(state::Integer, path::Integer, left_link, right_link)
   coordinate = Int[]
   !isnothing(left_link) && push!(coordinate, path)
   push!(coordinate, state, state)
@@ -79,18 +79,18 @@ function _mpo_coordinate(state::Integer, path::Integer, left_link, right_link)
   return coordinate
 end
 
-function _tensor_to_mpo(::Type{T}, entries, sites) where {T}
+function tensor_to_mpo(::Type{T}, entries, sites) where {T}
   site_vec = collect(sites)
   isempty(site_vec) && throw(ArgumentError("sites must not be empty"))
   all(site -> ITensors.dim(site) == 2, site_vec) ||
     throw(ArgumentError("projection MPO sites must be binary Qudit indices"))
 
   entry_vec = collect(entries)
-  _validate_sparse_entries(entry_vec, site_vec)
+  validate_sparse_entries(entry_vec, site_vec)
 
-  path_count = max(length(entry_vec), 1)
+  num_paths = max(length(entry_vec), 1)
   links = [
-    ITensors.Index(path_count, "Link,Projection,l=$i")
+    ITensors.Index(num_paths, "Link,Projection,l=$i")
     for i in 1:(length(site_vec) - 1)
   ]
 
@@ -100,11 +100,11 @@ function _tensor_to_mpo(::Type{T}, entries, sites) where {T}
     left_link = site_position == firstindex(site_vec) ? nothing : links[site_position - 1]
     right_link = site_position == lastindex(site_vec) ? nothing : links[site_position]
     if !isempty(entry_vec) && all(entry -> !haskey(entry.coordinates, site_position), entry_vec)
-      tensors[site_position] = _pass_through_tensor(T, site, left_link, right_link)
+      tensors[site_position] = pass_through_tensor(T, site, left_link, right_link)
       continue
     end
 
-    inds = _mpo_tensor_indices(site, left_link, right_link)
+    inds = mpo_tensor_indices(site, left_link, right_link)
     nonzeros = Tuple{Vector{Int},T}[]
 
     for (path, entry) in enumerate(entry_vec)
@@ -113,7 +113,7 @@ function _tensor_to_mpo(::Type{T}, entries, sites) where {T}
       coefficient = site_position == firstindex(site_vec) ? entry.value : one(T)
 
       for state in states
-        push!(nonzeros, (_mpo_coordinate(state, path, left_link, right_link), coefficient))
+        push!(nonzeros, (mpo_coordinate(state, path, left_link, right_link), coefficient))
       end
     end
 
@@ -123,7 +123,7 @@ function _tensor_to_mpo(::Type{T}, entries, sites) where {T}
   return ITensorMPS.MPO(tensors)
 end
 
-function _validate_sparse_entries(entries, sites)
+function validate_sparse_entries(entries, sites)
   for entry in entries
     for (site_position, coordinate) in entry.coordinates
       checkbounds(sites, site_position)
@@ -135,26 +135,41 @@ function _validate_sparse_entries(entries, sites)
   return nothing
 end
 
-function _constraint_sites(constraint::SumConstraint)
+function constraint_sites(constraint::SumConstraint)
   return constraint.sites
 end
 
-function _constraint_sites(constraint::NotEqualsConstraint)
+function constraint_sites(constraint::NotEqualsConstraint)
   return constraint.sites
 end
 
-function _constraint_sites(constraint::ExactlyOneConstraint)
+function constraint_sites(constraint::ExactlyOneConstraint)
   return constraint.sites
 end
 
-function _constraint_sites(constraint::RelationConstraint)
+function constraint_sites(constraint::RelationConstraint)
   return [constraint.left_site, constraint.right_site]
 end
 
-function _projection_entries(::Type{T}, constraint::AbstractConstraint) where {T}
-  constraint_sites = _constraint_sites(constraint)
+function projection_entries(::Type{T}, constraint::SumConstraint) where {T}
+  return projection_entries(T, constraint, constraint_sites(constraint))
+end
+
+function projection_entries(::Type{T}, constraint::NotEqualsConstraint) where {T}
+  return projection_entries(T, constraint, constraint_sites(constraint))
+end
+
+function projection_entries(::Type{T}, constraint::ExactlyOneConstraint) where {T}
+  return projection_entries(T, constraint, constraint_sites(constraint))
+end
+
+function projection_entries(::Type{T}, constraint::RelationConstraint) where {T}
+  return projection_entries(T, constraint, constraint_sites(constraint))
+end
+
+function projection_entries(::Type{T}, constraint::AbstractConstraint, constraint_sites) where {T}
   assignments = Iterators.product(fill(0:1, length(constraint_sites))...)
-  entries = _SparseTensorEntry{T}[]
+  entries = SparseTensorEntry{T}[]
 
   for assignment in assignments
     x = zeros(Int, maximum(constraint_sites))
@@ -166,7 +181,7 @@ function _projection_entries(::Type{T}, constraint::AbstractConstraint) where {T
     end
 
     if is_feasible(x, constraint)
-      push!(entries, _SparseTensorEntry{T}(coordinates, one(T)))
+      push!(entries, SparseTensorEntry{T}(coordinates, one(T)))
     end
   end
 
@@ -174,25 +189,49 @@ function _projection_entries(::Type{T}, constraint::AbstractConstraint) where {T
 end
 
 """
-    projection_mpo(constraint, sites)
+    projection_mpo([T], constraint, sites)
 
 Build a diagonal projection MPO that preserves basis states satisfying
 `constraint` and zeros infeasible states.
 """
-function projection_mpo(::Type{T}, constraint::AbstractConstraint, sites) where {T}
+function projection_mpo(::Type{T}, constraint::SumConstraint, sites) where {T}
+  return projection_mpo(T, constraint, constraint_sites(constraint), sites)
+end
+
+function projection_mpo(::Type{T}, constraint::NotEqualsConstraint, sites) where {T}
+  return projection_mpo(T, constraint, constraint_sites(constraint), sites)
+end
+
+function projection_mpo(::Type{T}, constraint::ExactlyOneConstraint, sites) where {T}
+  return projection_mpo(T, constraint, constraint_sites(constraint), sites)
+end
+
+function projection_mpo(::Type{T}, constraint::RelationConstraint, sites) where {T}
+  return projection_mpo(T, constraint, constraint_sites(constraint), sites)
+end
+
+function projection_mpo(::Type{T}, constraint::AbstractConstraint, constraint_sites, sites) where {T}
   site_vec = collect(sites)
-  constraint_sites = _constraint_sites(constraint)
   all(site -> 1 <= site <= length(site_vec), constraint_sites) ||
     throw(BoundsError(site_vec, maximum(constraint_sites)))
 
-  return _tensor_to_mpo(T, _projection_entries(T, constraint), site_vec)
+  return tensor_to_mpo(T, projection_entries(T, constraint), site_vec)
 end
 
-projection_mpo(constraint::AbstractConstraint, sites) =
+projection_mpo(constraint::SumConstraint, sites) =
+  projection_mpo(Float64, constraint, sites)
+
+projection_mpo(constraint::NotEqualsConstraint, sites) =
+  projection_mpo(Float64, constraint, sites)
+
+projection_mpo(constraint::ExactlyOneConstraint, sites) =
+  projection_mpo(Float64, constraint, sites)
+
+projection_mpo(constraint::RelationConstraint, sites) =
   projection_mpo(Float64, constraint, sites)
 
 """
-    projection_mpos(constraints, sites)
+    projection_mpos([T], constraints, sites)
 
 Build one projection MPO per constraint.
 """

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -151,16 +151,16 @@ function constraint_sites(constraint::RelationConstraint)
   return [constraint.left_site, constraint.right_site]
 end
 
-
-function projection_entries(::Type{T}, constraint::AbstractConstraint, constraint_sites) where {T}
-  assignments = Iterators.product(fill(0:1, length(constraint_sites))...)
+function projection_entries(::Type{T}, constraint::AbstractConstraint) where {T}
+  cs = constraint_sites(constraint)
+  assignments = Iterators.product(fill(0:1, length(cs))...)
   entries = SparseTensorEntry{T}[]
 
   for assignment in assignments
-    x = zeros(Int, maximum(constraint_sites))
+    x = zeros(Int, maximum(cs))
     coordinates = Dict{Int,Int}()
 
-    for (site, bit) in zip(constraint_sites, assignment)
+    for (site, bit) in zip(cs, assignment)
       x[site] = bit
       coordinates[site] = bit + 1
     end
@@ -179,10 +179,12 @@ end
 Build a diagonal projection MPO that preserves basis states satisfying
 `constraint` and zeros infeasible states.
 """
-function projection_mpo(::Type{T}, constraint::AbstractConstraint, constraint_sites, sites) where {T}
+function projection_mpo(::Type{T}, constraint::AbstractConstraint, sites) where {T}
+  cs = constraint_sites(constraint)
   site_vec = collect(sites)
-  all(site -> 1 <= site <= length(site_vec), constraint_sites) ||
-    throw(BoundsError(site_vec, maximum(constraint_sites)))
+
+  all(site -> 1 <= site <= length(site_vec), cs) ||
+    throw(BoundsError(site_vec, maximum(cs)))
 
   return tensor_to_mpo(T, projection_entries(T, constraint), site_vec)
 end

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -2,6 +2,14 @@
 # design in Sharma, Ritvik, Cheng Peng, Siddharth Dangwal, and Sara Achour,
 # "CoTenN: Constrained Optimization with Tensor Networks," PLDI 2026.
 
+"""
+    SparseTensorEntry{T}
+
+One nonzero term in the sparse representation used to assemble a projection
+MPO. `coordinates` maps 1-based register sites to 1-based local basis states;
+sites omitted from the dictionary are unconstrained by this entry. `value` is
+the coefficient carried by that partial assignment.
+"""
 struct SparseTensorEntry{T}
   coordinates::Dict{Int,Int}
   value::T
@@ -88,6 +96,9 @@ function tensor_to_mpo(::Type{T}, entries, sites) where {T}
   entry_vec = collect(entries)
   validate_sparse_entries(entry_vec, site_vec)
 
+  # Each feasible partial assignment gets one path threaded through the MPO
+  # links. Constrained sites write that assignment; unconstrained sites pass the
+  # path and physical basis state through unchanged.
   num_paths = max(length(entry_vec), 1)
   links = [
     ITensors.Index(num_paths, "Link,Projection,l=$i")
@@ -135,6 +146,9 @@ function validate_sparse_entries(entries, sites)
   return nothing
 end
 
+# Enumerate feasible assignments on the sites touched by `constraint`. The
+# resulting sparse entries intentionally omit untouched sites; `tensor_to_mpo`
+# expands those missing coordinates into pass-through tensors.
 function projection_entries(::Type{T}, constraint::AbstractConstraint) where {T}
   cs = constraint_sites(constraint)
   assignments = Iterators.product(fill(0:1, length(cs))...)
@@ -160,8 +174,12 @@ end
 """
     projection_mpo([T], constraint, sites)
 
-Build a diagonal projection MPO that preserves basis states satisfying
-`constraint` and zeros infeasible states.
+Build a diagonal projection MPO over the binary Qudit register `sites`.
+
+The diagonal entry is `one(T)` for computational basis states whose bits satisfy
+`constraint`, and zero otherwise. Constraint site numbers use the same 1-based
+register indexing as `sites`. The construction is exact and uncompressed: each
+feasible assignment of the constrained sites is represented as one MPO path.
 """
 function projection_mpo(::Type{T}, constraint::AbstractConstraint, sites) where {T}
   cs = constraint_sites(constraint)
@@ -179,7 +197,12 @@ projection_mpo(constraint::AbstractConstraint, sites) =
 """
     projection_mpos([T], constraints, sites)
 
-Build one projection MPO per constraint.
+Build one projection MPO per constraint over the shared binary Qudit register
+`sites`.
+
+This is a convenience wrapper around [`projection_mpo`](@ref) that reuses the
+same collected site register for every constraint. `T` controls the numeric
+element type of the assembled MPO tensors.
 """
 function projection_mpos(::Type{T}, constraints::AbstractVector{<:AbstractConstraint}, sites) where {T}
   site_vec = collect(sites)

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -135,22 +135,6 @@ function validate_sparse_entries(entries, sites)
   return nothing
 end
 
-function constraint_sites(constraint::SumConstraint)
-  return constraint.sites
-end
-
-function constraint_sites(constraint::NotEqualsConstraint)
-  return constraint.sites
-end
-
-function constraint_sites(constraint::ExactlyOneConstraint)
-  return constraint.sites
-end
-
-function constraint_sites(constraint::RelationConstraint)
-  return [constraint.left_site, constraint.right_site]
-end
-
 function projection_entries(::Type{T}, constraint::AbstractConstraint) where {T}
   cs = constraint_sites(constraint)
   assignments = Iterators.product(fill(0:1, length(cs))...)

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -6,6 +6,8 @@ import MultivariatePolynomials: AbstractPolynomial, coefficient, monomial, terms
 maybe(f::Function, mx::Nothing; default=nothing) = default
 maybe(f::Function, mx; default=nothing) = f(mx)
 
+ifnotnothing(a, b) = maybe(_ -> b, a)
+
 """
     AbstractTenSolverBackend
 

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -48,6 +48,20 @@ end
     @test count(!iszero, materialized) == 2
   end
 
+  @testset "Entry value on a pass-through leading site" begin
+    # Regression: the entry `value` must survive even when the first register
+    # site is a pass-through site. Here only site 2 is constrained, so sites 1
+    # and 3 pass through; the coefficient must be anchored on site 2.
+    entry = TenSolver.SparseTensorEntry(Dict(2 => 2), 7.0)
+    H = TenSolver.tensor_to_mpo(Float64, [entry], sites)
+    diagonal = projection_diagonal(H, sites)
+
+    for (bits, value) in diagonal
+      expected = bits[2] == 1 ? 7.0 : 0.0
+      @test value ≈ expected
+    end
+  end
+
   @testset "Validation errors" begin
     s1 = sites[1]
     s1p = ITensors.prime(s1)

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -30,6 +30,21 @@ end
     @test count(!iszero, materialized) == 2
   end
 
+  @testset "Validation errors" begin
+    s1 = sites[1]
+    s1p = ITensors.prime(s1)
+    qutrit_sites = ITensors.siteinds("Qudit", 1; dim=3)
+
+    @test_throws DimensionMismatch TenSolver.itensor_from_nonzeros(
+      Float64,
+      (s1, s1p),
+      [((1, 1, 1), 1.0)],
+    )
+    @test_throws ArgumentError TenSolver._tensor_to_mpo(Float64, [], ITensors.Index{Int64}[])
+    @test_throws ArgumentError TenSolver._tensor_to_mpo(Float64, [], qutrit_sites)
+    @test_throws BoundsError TenSolver.projection_mpo(exactly_one_constraint([4]), sites)
+  end
+
   @testset "Manual diagonal masks" begin
     constraint = not_equals_constraint([1, 3], [1, 0])
     H = TenSolver.projection_mpo(constraint, sites)

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -15,6 +15,24 @@ end
 @testset "Projection MPOs" begin
   sites = ITensors.siteinds("Qudit", 3; dim=2)
 
+  @testset "Projection API inference" begin
+    constraint = ExactlyOneConstraint([1, 2])
+    constraints = AbstractConstraint[
+      constraint,
+      RelationConstraint(1, Symbol("<="), 2),
+    ]
+
+    typed_mpo = @inferred TenSolver.projection_mpo(Float64, constraint, sites)
+    default_mpo = @inferred TenSolver.projection_mpo(constraint, sites)
+    typed_mpos = @inferred TenSolver.projection_mpos(Float64, constraints, sites)
+    default_mpos = @inferred TenSolver.projection_mpos(constraints, sites)
+
+    @test typed_mpo isa ITensorMPS.MPO
+    @test default_mpo isa ITensorMPS.MPO
+    @test typed_mpos isa Vector{ITensorMPS.MPO}
+    @test default_mpos isa Vector{ITensorMPS.MPO}
+  end
+
   @testset "Sparse ITensor construction" begin
     s1, s2 = sites[1], sites[2]
     s1p, s2p = ITensors.prime(s1), ITensors.prime(s2)

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -1,0 +1,71 @@
+import ITensors, ITensorMPS
+
+function _projection_diagonal(H, sites)
+  diagonal = Dict{Vector{Int},Float64}()
+
+  for assignment in Iterators.product(fill(0:1, length(sites))...)
+    bits = collect(assignment)
+    psi = ITensorMPS.MPS(sites, string.(bits))
+    diagonal[bits] = real(ITensors.inner(adjoint(psi), H, psi))
+  end
+
+  return diagonal
+end
+
+@testset "Projection MPOs" begin
+  sites = ITensors.siteinds("Qudit", 3; dim=2)
+
+  @testset "Sparse ITensor construction" begin
+    s1, s2 = sites[1], sites[2]
+    s1p, s2p = ITensors.prime(s1), ITensors.prime(s2)
+    tensor = TenSolver.itensor_from_nonzeros(
+      Float64,
+      (s1, s1p, s2, s2p),
+      [((1, 1, 2, 2), 3.0), ((2, 2, 1, 1), 5.0)],
+    )
+    materialized = Array(tensor, s1, s1p, s2, s2p)
+
+    @test materialized[1, 1, 2, 2] == 3.0
+    @test materialized[2, 2, 1, 1] == 5.0
+    @test count(!iszero, materialized) == 2
+  end
+
+  @testset "Manual diagonal masks" begin
+    constraint = not_equals_constraint([1, 3], [1, 0])
+    H = TenSolver.projection_mpo(constraint, sites)
+    diagonal = _projection_diagonal(H, sites)
+
+    for bits in keys(diagonal)
+      expected = is_feasible(bits, constraint) ? 1.0 : 0.0
+      @test diagonal[bits] ≈ expected
+    end
+  end
+
+  @testset "Feasible states are preserved" begin
+    constraints = AbstractConstraint[
+      exactly_one_constraint([1, 2, 3]),
+      relation_constraint(1, Symbol("<="), 2),
+      sum_constraint([1, 3], [2, 1], Symbol("<="), 2),
+    ]
+    projections = TenSolver.projection_mpos(constraints, sites)
+
+    @test length(projections) == length(constraints)
+
+    for (constraint, H) in zip(constraints, projections)
+      diagonal = _projection_diagonal(H, sites)
+
+      for bits in keys(diagonal)
+        expected = is_feasible(bits, constraint) ? 1.0 : 0.0
+        @test diagonal[bits] ≈ expected
+      end
+    end
+  end
+
+  @testset "Infeasible constraints build zero masks" begin
+    constraint = sum_constraint([1, 2], [1, 1], Symbol("<"), 0)
+    H = TenSolver.projection_mpo(constraint, sites)
+    diagonal = _projection_diagonal(H, sites)
+
+    @test all(iszero, values(diagonal))
+  end
+end

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -1,6 +1,6 @@
 import ITensors, ITensorMPS
 
-function _projection_diagonal(H, sites)
+function projection_diagonal(H, sites)
   diagonal = Dict{Vector{Int},Float64}()
 
   for assignment in Iterators.product(fill(0:1, length(sites))...)
@@ -40,15 +40,15 @@ end
       (s1, s1p),
       [((1, 1, 1), 1.0)],
     )
-    @test_throws ArgumentError TenSolver._tensor_to_mpo(Float64, [], ITensors.Index{Int64}[])
-    @test_throws ArgumentError TenSolver._tensor_to_mpo(Float64, [], qutrit_sites)
+    @test_throws ArgumentError TenSolver.tensor_to_mpo(Float64, [], ITensors.Index{Int64}[])
+    @test_throws ArgumentError TenSolver.tensor_to_mpo(Float64, [], qutrit_sites)
     @test_throws BoundsError TenSolver.projection_mpo(ExactlyOneConstraint([4]), sites)
   end
 
   @testset "Manual diagonal masks" begin
     constraint = NotEqualsConstraint([1, 3], [1, 0])
     H = TenSolver.projection_mpo(constraint, sites)
-    diagonal = _projection_diagonal(H, sites)
+    diagonal = projection_diagonal(H, sites)
 
     for bits in keys(diagonal)
       expected = is_feasible(bits, constraint) ? 1.0 : 0.0
@@ -67,7 +67,7 @@ end
     @test length(projections) == length(constraints)
 
     for (constraint, H) in zip(constraints, projections)
-      diagonal = _projection_diagonal(H, sites)
+      diagonal = projection_diagonal(H, sites)
 
       for bits in keys(diagonal)
         expected = is_feasible(bits, constraint) ? 1.0 : 0.0
@@ -79,7 +79,7 @@ end
   @testset "Infeasible constraints build zero masks" begin
     constraint = SumConstraint([1, 2], [1, 1], Symbol("<="), -1)
     H = TenSolver.projection_mpo(constraint, sites)
-    diagonal = _projection_diagonal(H, sites)
+    diagonal = projection_diagonal(H, sites)
 
     @test all(iszero, values(diagonal))
   end

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -42,11 +42,11 @@ end
     )
     @test_throws ArgumentError TenSolver._tensor_to_mpo(Float64, [], ITensors.Index{Int64}[])
     @test_throws ArgumentError TenSolver._tensor_to_mpo(Float64, [], qutrit_sites)
-    @test_throws BoundsError TenSolver.projection_mpo(exactly_one_constraint([4]), sites)
+    @test_throws BoundsError TenSolver.projection_mpo(ExactlyOneConstraint([4]), sites)
   end
 
   @testset "Manual diagonal masks" begin
-    constraint = not_equals_constraint([1, 3], [1, 0])
+    constraint = NotEqualsConstraint([1, 3], [1, 0])
     H = TenSolver.projection_mpo(constraint, sites)
     diagonal = _projection_diagonal(H, sites)
 
@@ -58,9 +58,9 @@ end
 
   @testset "Feasible states are preserved" begin
     constraints = AbstractConstraint[
-      exactly_one_constraint([1, 2, 3]),
-      relation_constraint(1, Symbol("<="), 2),
-      sum_constraint([1, 3], [2, 1], Symbol("<="), 2),
+      ExactlyOneConstraint([1, 2, 3]),
+      RelationConstraint(1, Symbol("<="), 2),
+      SumConstraint([1, 3], [2, 1], Symbol("<="), 2),
     ]
     projections = TenSolver.projection_mpos(constraints, sites)
 
@@ -77,7 +77,7 @@ end
   end
 
   @testset "Infeasible constraints build zero masks" begin
-    constraint = sum_constraint([1, 2], [1, 1], Symbol("<"), 0)
+    constraint = SumConstraint([1, 2], [1, 1], Symbol("<="), -1)
     H = TenSolver.projection_mpo(constraint, sites)
     diagonal = _projection_diagonal(H, sites)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ include(filepath("ising_conversion.jl"))
 
 # Binary constraint API
 include(filepath("constraints.jl"))
+include(filepath("projection_mpo.jl"))
 
 # Traditional interface
 include(filepath("qubo.jl"))


### PR DESCRIPTION
## Summary

- Adds internal sparse ITensor construction and tensor-to-MPO assembly helpers for diagonal projection masks.
- Adds `projection_mpo(constraint, sites)` and `projection_mpos(constraints, sites)` for binary constraints over Qudit sites.
- Adds focused tests that materialize small projection masks and compare feasible/infeasible basis-state behavior against `is_feasible`.

Closes #57.

## Tests

- `julia --project=/tmp/tensolver-issue57-testenv -e 'using Test, TenSolver; include("test/projection_mpo.jl")'` passed.
- `julia --project=/tmp/tensolver-issue57-testenv -e 'using Test, TenSolver; include("test/constraints.jl"); include("test/projection_mpo.jl")'` passed.
- `julia --project=. -e 'using Pkg; Pkg.test()'` passed.

## Branch Hygiene

- Base branch: `pr-1-constraint-api` (temporary stacked base for PR #84 / issue #56; retarget to `main` after #84 merges)
- Source branch point: `origin/pr-1-constraint-api` at `f6a2f80a6c2cd46d97d21cd27fb0885f92bcf9c6`
- Stacked status: stacked on PR #84 by issue request; opened as draft
- Prerequisite PRs: #84
