### PR TITLE
Document and test NotEqualsConstraint projection

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -47,8 +47,9 @@ struct SumConstraint{T<:Real} <: AbstractConstraint
     rhs        = validate_rhs(rhs)
 
     weight_map = Dict(site => weight for (site, weight) in zip(site_vec, weight_vec))
-    length(weight_map) == length(site_vec) ||
+    if length(weight_map) != length(site_vec)
       throw(ArgumentError("sites must be unique"))
+    end
 
     return new{T}(weight_map, relation, rhs)
   end
@@ -84,17 +85,31 @@ Excludes a single assignment over a binary vector `x`: at least one component of
 `sites` must be unique positive integers, and `values` must contain only binary
 values (`0` or `1`) with the same length as `sites`.
 """
-struct NotEqualsConstraint <: AbstractConstraint
-  sites::Vector{Int}
-  values::Vector{Int}
+struct NotEqualsConstraint{T<:Real} <: AbstractConstraint
+  values::Dict{Int, T}
 
-  function NotEqualsConstraint(sites, values)
-    site_vec = validate_sites(sites)
+  function NotEqualsConstraint{T}(sites, values::AbstractVector{T}) where {T<:Real}
+    site_vec  = validate_sites(sites)
     value_vec = validate_binary_values(values, "values")
     validate_same_length(site_vec, value_vec, "sites", "values")
 
-    return new(site_vec, value_vec)
+    value_map = Dict{Int,T}(site => value for (site, value) in zip(site_vec, value_vec))
+    if length(value_map) != length(site_vec)
+      throw(ArgumentError("sites must be unique"))
+    end
+
+    return new{T}(value_map)
   end
+end
+
+function NotEqualsConstraint(sites, values)
+  raw_values = collect(values)
+  isempty(raw_values) && throw(ArgumentError("values must not be empty"))
+
+  T = promote_type(map(typeof, raw_values)...)
+  T <: Real || throw(ArgumentError("values must be real-valued"))
+
+  return NotEqualsConstraint{T}(sites, T.(raw_values))
 end
 
 """
@@ -153,10 +168,7 @@ function is_feasible(x::AbstractVector, constraint::SumConstraint)
 end
 
 function is_feasible(x::AbstractVector, constraint::NotEqualsConstraint)
-  return any(
-    binary_at(x, constraint.sites[i]) != constraint.values[i]
-    for i in eachindex(constraint.sites, constraint.values)
-  )
+  return any(binary_at(x, site) != value for (site, value) in constraint.values)
 end
 
 function is_feasible(x::AbstractVector, constraint::ExactlyOneConstraint)
@@ -197,7 +209,7 @@ function constraint_sites(constraint::SumConstraint)
 end
 
 function constraint_sites(constraint::NotEqualsConstraint)
-  return constraint.sites
+  return sort!(collect(keys(constraint.values)))
 end
 
 function constraint_sites(constraint::ExactlyOneConstraint)
@@ -294,7 +306,7 @@ function validate_binary_values(values, name)
     throw(ArgumentError("$name must contain only binary values 0 or 1"))
   end
 
-  return Int.(values)
+  return values
 end
 
 function binary_at(x, site)

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -227,6 +227,9 @@ The construction is exact and uncompressed. Constraint site numbers use the same
 
 - `SumConstraint` uses a specialized exact integer partial-sum automaton.
 For a constraint with rhs `k`, its maximum bond dimension is `k+2`.
+- `NotEqualsConstraint` uses the generic exact assignment enumeration path.
+  It is a bounded-size local constraint: the diagonal MPO entries are `one(T)`
+  for assignments that avoid the forbidden tuple, and zero otherwise.
 """
 function projection_mpo end
 

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -417,22 +417,21 @@ function constraint_to_dfa(constraint::SumConstraint{S}, sites) where {S}
   return DFA(states, alphabet, zero(S), accepting, transitions)
 end
 
-function constraint_to_dfa(constraint::NotEqualsConstraint, sites)
+function constraint_to_dfa(constraint::NotEqualsConstraint{S}, sites) where {S}
   validate_projection_sites(sites)
 
   cs = constraint_sites(constraint)
   validate_constraint_site_bounds(cs, sites)
 
-  value_map = Dict(site => value for (site, value) in zip(constraint.sites, constraint.values))
-  states    = [0, 1]
+  states    = S.([0, 1])
   alphabet  = [0, 1]
   initial   = 1
-  accepting = Set([0])
+  accepting = Set(0)
 
   transitions = [
-    let target = get(value_map, i, nothing)
+    let target = get(constraint.values, i, nothing)
       Dict{Tuple{Int,Int},Int}(
-        (q, a) => isnothing(target) | a == target ? q : 0
+        (q, a) => isnothing(target) || S(a) == target ? q : 0
         for q in states, a in alphabet
       )
     end

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -225,11 +225,10 @@ The construction is exact and uncompressed. Constraint site numbers use the same
 
 # Known constraints
 
-- `SumConstraint` uses a specialized exact integer partial-sum automaton.
+- [`SumConstraint`](@ref) uses a specialized exact integer partial-sum automaton.
 For a constraint with rhs `k`, its maximum bond dimension is `k+2`.
-- `NotEqualsConstraint` uses the generic exact assignment enumeration path.
-  It is a bounded-size local constraint: the diagonal MPO entries are `one(T)`
-  for assignments that avoid the forbidden tuple, and zero otherwise.
+- [`NotEqualsConstraint`](@ref) uses a specialized MPO with bond dimension `2`,
+  independently of the rhs.
 """
 function projection_mpo end
 
@@ -416,4 +415,29 @@ function constraint_to_dfa(constraint::SumConstraint{S}, sites) where {S}
   ]
 
   return DFA(states, alphabet, zero(S), accepting, transitions)
+end
+
+function constraint_to_dfa(constraint::NotEqualsConstraint, sites)
+  validate_projection_sites(sites)
+
+  cs = constraint_sites(constraint)
+  validate_constraint_site_bounds(cs, sites)
+
+  value_map = Dict(site => value for (site, value) in zip(constraint.sites, constraint.values))
+  states    = [0, 1]
+  alphabet  = [0, 1]
+  initial   = 1
+  accepting = Set([0])
+
+  transitions = [
+    let target = get(value_map, i, nothing)
+      Dict{Tuple{Int,Int},Int}(
+        (q, a) => isnothing(target) | a == target ? q : 0
+        for q in states, a in alphabet
+      )
+    end
+    for i in eachindex(sites)
+  ]
+
+  return DFA(states, alphabet, initial, accepting, transitions)
 end

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -14,10 +14,15 @@
     @test keyword_sum.rhs == 2.0
 
     not_equals = NotEqualsConstraint([1, 2], [1, 0])
-    @test not_equals isa NotEqualsConstraint
+    @test not_equals isa NotEqualsConstraint{Int}
     @test not_equals isa AbstractConstraint
-    @test not_equals.sites == [1, 2]
-    @test not_equals.values == [1, 0]
+    @test TenSolver.constraint_sites(not_equals) == [1, 2]
+    @test not_equals.values == Dict(1 => 1, 2 => 0)
+
+    float_not_equals = NotEqualsConstraint([1, 2], [1.0, 0.0])
+    @test float_not_equals isa NotEqualsConstraint{Float64}
+    @test TenSolver.constraint_sites(float_not_equals) == [1, 2]
+    @test float_not_equals.values == Dict(1 => 1.0, 2 => 0.0)
 
     exactly_one = ExactlyOneConstraint(2:4)
     @test exactly_one isa ExactlyOneConstraint

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -8,6 +8,17 @@ function mpo_diagonal(H, sites, bits)
   return real(ITensors.inner(psi', H, psi))
 end
 
+function assert_projection_matches_feasibility(constraint, sites)
+  H = TenSolver.projection_mpo(constraint, sites)
+
+  for bits in all_bitstrings(sites)
+    expected = Float64(is_feasible(collect(bits), constraint))
+    @test mpo_diagonal(H, sites, bits) == expected
+  end
+
+  return H
+end
+
 function dfa_accepts(dfa, input)
   state = dfa.initial
 
@@ -54,6 +65,7 @@ end
     SumConstraint([1, 2, 4], [1, 2, 3], :(==), 3),
     SumConstraint([2, 4], [2, 3], :(>=), 3),
     SumConstraint([1, 2, 4], [1, 2, 3], :(!=), 3),
+    NotEqualsConstraint([1, 3], [1, 0]),
   ]
 
   @testset "DFA correctness" begin
@@ -117,12 +129,41 @@ end
     sites = ITensors.siteinds("Qudit", 4; dim=2)
 
     for constraint in TEST_CONSTRAINTS
-      H = TenSolver.projection_mpo(constraint, sites)
+      assert_projection_matches_feasibility(constraint, sites)
+    end
+  end
+
+  @testset "NotEqualsConstraint projection" begin
+    sites = ITensors.siteinds("Qudit", 4; dim=2)
+
+    forbidden_tuple = NotEqualsConstraint([1, 3, 4], [1, 0, 1])
+    H = assert_projection_matches_feasibility(forbidden_tuple, sites)
+
+    for bits in all_bitstrings(sites)
+      forbidden = bits[1] == 1 && bits[3] == 0 && bits[4] == 1
+      @test mpo_diagonal(H, sites, bits) == Float64(!forbidden)
+    end
+    @test ITensorMPS.maxlinkdim(H) <= 14
+
+    local_exclusions = [
+      NotEqualsConstraint([i, i + 1], [1, 1])
+      for i in 1:3
+    ]
+    Hs = TenSolver.projection_mpos(local_exclusions, sites)
+
+    for (constraint, local_H) in zip(local_exclusions, Hs)
+      left, right = TenSolver.constraint_sites(constraint)
 
       for bits in all_bitstrings(sites)
-        expected = Float64(is_feasible(collect(bits), constraint))
-        @test mpo_diagonal(H, sites, bits) ≈ expected
+        forbidden = bits[left] == 1 && bits[right] == 1
+        @test mpo_diagonal(local_H, sites, bits) == Float64(!forbidden)
       end
+      @test ITensorMPS.maxlinkdim(local_H) <= 6
+    end
+
+    for bits in all_bitstrings(sites)
+      has_adjacent_ones = any(i -> bits[i] == 1 && bits[i + 1] == 1, 1:3)
+      @test is_feasible(collect(bits), local_exclusions) == !has_adjacent_ones
     end
   end
 

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -143,7 +143,7 @@ end
       forbidden = bits[1] == 1 && bits[3] == 0 && bits[4] == 1
       @test mpo_diagonal(H, sites, bits) == Float64(!forbidden)
     end
-    @test ITensorMPS.maxlinkdim(H) <= 14
+    @test ITensorMPS.maxlinkdim(H) <= 2
 
     local_exclusions = [
       NotEqualsConstraint([i, i + 1], [1, 1])

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -66,6 +66,8 @@ end
     SumConstraint([2, 4], [2, 3], :(>=), 3),
     SumConstraint([1, 2, 4], [1, 2, 3], :(!=), 3),
     NotEqualsConstraint([1, 3], [1, 0]),
+    NotEqualsConstraint([1, 2], [1.0, 0.0]),
+    NotEqualsConstraint([1, 3, 2, 4], Bool[1, 0, 0, 1]),
   ]
 
   @testset "DFA correctness" begin
@@ -158,7 +160,7 @@ end
         forbidden = bits[left] == 1 && bits[right] == 1
         @test mpo_diagonal(local_H, sites, bits) == Float64(!forbidden)
       end
-      @test ITensorMPS.maxlinkdim(local_H) <= 6
+      @test ITensorMPS.maxlinkdim(local_H) <= 2
     end
 
     for bits in all_bitstrings(sites)


### PR DESCRIPTION
## Summary

Refs #59.

- Document that `NotEqualsConstraint` uses the generic exact projection-MPO assignment path.
- Add exact diagonal projection checks for `NotEqualsConstraint`, including a non-contiguous forbidden tuple.
- Add PXP-style local exclusion coverage for adjacent `11` patterns through `projection_mpos`.

`RelationConstraint` projection is intentionally deferred to a follow-up PR so issue #59 is split one constraint at a time.

## Tests

- `julia --project=. -e 'using Pkg; Pkg.instantiate(); using Test, TenSolver; include("test/projection_mpo.jl")'`
- `julia --project=. -e 'using Pkg; Pkg.test(; coverage=false)'`

## Branch Hygiene

- Base branch: `main`
- Source branch: `pr-4-notequals-projection`
- Branch point: `3996201` (`origin/main`)
- Stacked status: not stacked; prerequisite #58 / PR #86 has merged into `main`
- Follow-up: split `RelationConstraint` projection into a separate PR
