### PR TITLE
Implement RelationConstraint projection MPO

### DIFF
--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -229,6 +229,8 @@ The construction is exact and uncompressed. Constraint site numbers use the same
 For a constraint with rhs `k`, its maximum bond dimension is `k+2`.
 - [`NotEqualsConstraint`](@ref) uses a specialized MPO with bond dimension `2`,
   independently of the rhs.
+- [`RelationConstraint`](@ref) uses a specialized MPO with bond dimension `3`,
+  independently of the compared site positions.
 """
 function projection_mpo end
 
@@ -439,4 +441,50 @@ function constraint_to_dfa(constraint::NotEqualsConstraint{S}, sites) where {S}
   ]
 
   return DFA(states, alphabet, initial, accepting, transitions)
+end
+
+function constraint_to_dfa(constraint::RelationConstraint, sites)
+  validate_projection_sites(sites)
+
+  cs = constraint_sites(constraint)
+  validate_constraint_site_bounds(cs, sites)
+
+  (; left_site, relation, right_site) = constraint
+  first_site = min(left_site, right_site)
+  second_site = max(left_site, right_site)
+  left_is_first = left_site == first_site
+
+  pass = 0
+  seen_zero = 1
+  seen_one = 2
+  seen_states = ((seen_zero, 0), (seen_one, 1))
+
+  states = [pass, seen_zero, seen_one]
+  alphabet = [0, 1]
+
+  # The step-dependent DFA reuses `pass` before the first relation endpoint and
+  # after the relation has accepted. Between endpoints it stores the first bit.
+  transitions = [
+    if i == first_site
+      Dict{Tuple{Int,Int},Int}(
+        (pass, a) => (a == 0 ? seen_zero : seen_one)
+        for a in alphabet
+      )
+    elseif i == second_site
+      Dict{Tuple{Int,Int},Int}(
+        (seen_state, a) => pass
+        for (seen_state, first_value) in seen_states, a in alphabet
+        if relation_holds(
+          left_is_first ? first_value : a,
+          relation,
+          left_is_first ? a : first_value,
+        )
+      )
+    else
+      Dict{Tuple{Int,Int},Int}((q, a) => q for q in states, a in alphabet)
+    end
+    for i in eachindex(sites)
+  ]
+
+  return DFA(states, alphabet, pass, Set([pass]), transitions)
 end

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -229,7 +229,7 @@ The construction is exact and uncompressed. Constraint site numbers use the same
 For a constraint with rhs `k`, its maximum bond dimension is `k+2`.
 - [`NotEqualsConstraint`](@ref) uses a specialized MPO with bond dimension `2`,
   independently of the rhs.
-- [`RelationConstraint`](@ref) uses a specialized MPO with bond dimension `3`,
+- [`RelationConstraint`](@ref) uses a specialized MPO with bond dimension `2`,
   independently of the compared site positions.
 """
 function projection_mpo end
@@ -450,35 +450,25 @@ function constraint_to_dfa(constraint::RelationConstraint, sites)
   validate_constraint_site_bounds(cs, sites)
 
   (; left_site, relation, right_site) = constraint
-  first_site = min(left_site, right_site)
-  second_site = max(left_site, right_site)
+  first_site    = min(left_site, right_site)
+  second_site   = max(left_site, right_site)
   left_is_first = left_site == first_site
 
-  pass = 0
-  seen_zero = 1
-  seen_one = 2
-  seen_states = ((seen_zero, 0), (seen_one, 1))
+  states    = [0, 1]
+  alphabet  = [0, 1]
+  initial   = 1
+  accepting = Set(states)
 
-  states = [pass, seen_zero, seen_one]
-  alphabet = [0, 1]
-
-  # The step-dependent DFA reuses `pass` before the first relation endpoint and
-  # after the relation has accepted. Between endpoints it stores the first bit.
   transitions = [
     if i == first_site
-      Dict{Tuple{Int,Int},Int}(
-        (pass, a) => (a == 0 ? seen_zero : seen_one)
-        for a in alphabet
-      )
+      Dict{Tuple{Int,Int},Int}((q, a) => a for q in states, a in alphabet)
     elseif i == second_site
       Dict{Tuple{Int,Int},Int}(
-        (seen_state, a) => pass
-        for (seen_state, first_value) in seen_states, a in alphabet
-        if relation_holds(
-          left_is_first ? first_value : a,
-          relation,
-          left_is_first ? a : first_value,
-        )
+        (q, a) => q
+        for q in states, a in alphabet
+        if left_is_first ?
+          relation_holds(q, relation, a) :
+          relation_holds(a, relation, q)
       )
     else
       Dict{Tuple{Int,Int},Int}((q, a) => q for q in states, a in alphabet)
@@ -486,5 +476,5 @@ function constraint_to_dfa(constraint::RelationConstraint, sites)
     for i in eachindex(sites)
   ]
 
-  return DFA(states, alphabet, pass, Set([pass]), transitions)
+  return DFA(states, alphabet, initial, accepting, transitions)
 end

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -181,14 +181,14 @@ end
 
     for constraint in relation_cases
       dfa = TenSolver.constraint_to_dfa(constraint, sites)
-      @test length(dfa.states) == 3
+      @test length(dfa.states) <= 2
 
       for bits in all_bitstrings(sites)
         @test dfa_accepts(dfa, bits) == is_feasible(collect(bits), constraint)
       end
 
       H = assert_projection_matches_feasibility(constraint, sites)
-      @test ITensorMPS.maxlinkdim(H) <= 3
+      @test ITensorMPS.maxlinkdim(H) <= 2
     end
   end
 

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -68,6 +68,7 @@ end
     NotEqualsConstraint([1, 3], [1, 0]),
     NotEqualsConstraint([1, 2], [1.0, 0.0]),
     NotEqualsConstraint([1, 3, 2, 4], Bool[1, 0, 0, 1]),
+    RelationConstraint(4, :(<=), 2),
   ]
 
   @testset "DFA correctness" begin
@@ -166,6 +167,28 @@ end
     for bits in all_bitstrings(sites)
       has_adjacent_ones = any(i -> bits[i] == 1 && bits[i + 1] == 1, 1:3)
       @test is_feasible(collect(bits), local_exclusions) == !has_adjacent_ones
+    end
+  end
+
+  @testset "RelationConstraint projection" begin
+    sites = ITensors.siteinds("Qudit", 5; dim=2)
+
+    relation_cases = [
+      RelationConstraint(left, relation, right)
+      for relation in (:(==), :(!=), :(<=), :(>=))
+      for (left, right) in ((1, 4), (4, 1), (2, 5), (5, 2))
+    ]
+
+    for constraint in relation_cases
+      dfa = TenSolver.constraint_to_dfa(constraint, sites)
+      @test length(dfa.states) == 3
+
+      for bits in all_bitstrings(sites)
+        @test dfa_accepts(dfa, bits) == is_feasible(collect(bits), constraint)
+      end
+
+      H = assert_projection_matches_feasibility(constraint, sites)
+      @test ITensorMPS.maxlinkdim(H) <= 3
     end
   end
 


### PR DESCRIPTION
## Summary

Closes #59.

- Add a specialized `constraint_to_dfa(::RelationConstraint, sites)` lowering for pairwise binary relations.
- Keep the relation projection MPO at constant bond dimension 3 by storing only the first endpoint value until the second endpoint is read.
- Add brute-force DFA and MPO diagonal checks for all v1 relation senses (`==`, `!=`, `<=`, `>=`), both endpoint orders, and non-contiguous sites.
- Document `RelationConstraint`'s expected projection bond dimension in the projection-MPO docstring.

## Scope Notes

- PR #89 completed the `NotEqualsConstraint` half of #59.
- The strict `<` and `>` relation senses listed in the original issue body are stale after PR #84; v1 `RelationConstraint` intentionally supports only `==`, `!=`, `<=`, and `>=`.
- This PR therefore closes the remaining accepted v1 scope for #59: pairwise `RelationConstraint` projection over the supported relation set.

## Tests

- `git diff --check`
- `julia +1.12 --project=. -e 'using Test, TenSolver, ITensors, ITensorMPS; include("test/projection_mpo.jl")'`
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test(; coverage=false)'`

## Branch Hygiene

- Base branch: `main`
- Source branch: `pr-4-relation-projection`
- Branch point: `a30f0cd8213667dc8c2d39560f7ac56b09be3261` (`origin/main`)
- Stacked status: not stacked; #57, #58, and PR #89 have merged into `main`
- Scope note: PR #89 completed the `NotEqualsConstraint` half of #59; this PR implements the remaining `RelationConstraint` projection.
