### PR TITLE
Add projected Hamiltonian utilities

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -82,6 +82,13 @@ TenSolver.SparseTensorEntry
 TenSolver.projection_entries
 ```
 
+### Projected Hamiltonian Construction
+
+```@docs
+TenSolver.project_hamiltonian
+TenSolver.project_state
+```
+
 ## Index
 
 ```@index

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -261,6 +261,76 @@ end
 projection_mpos(constraints::AbstractVector{<:AbstractConstraint}, sites) =
   projection_mpos(Float64, constraints, sites)
 
+"""
+    project_hamiltonian(H, projections; cutoff=1e-8, kwargs...)
+
+Apply one or more diagonal projection MPOs to a Hamiltonian MPO.
+
+For projection MPOs `P`, this builds the CoTenN-style effective Hamiltonian
+`P' * H * P`. The projection MPOs produced by [`projection_mpo`](@ref) are
+real diagonal projectors, so the implementation composes them as `P * H * P`
+using ITensorMPS' `apply` helper to contract the MPOs and restore the usual
+unprimed/primed site-index structure expected by DMRG. The resulting bond
+dimension can grow with the product of `H`'s links and the projection links.
+"""
+function project_hamiltonian(H::ITensorMPS.MPO, projections; cutoff=1e-8, kwargs...)
+  projection_tuple = projection_sequence(projections)
+  target_sites = projection_target_sites(H)
+  validate_projection_sequence(target_sites, projection_tuple)
+
+  H_eff = H
+  for P in projection_tuple
+    H_eff = ITensors.apply(P, H_eff; cutoff, kwargs...)
+    H_eff = ITensors.apply(H_eff, P; cutoff, kwargs...)
+  end
+
+  return H_eff
+end
+
+"""
+    project_state(psi, projections; cutoff=1e-8, kwargs...)
+
+Apply one or more diagonal projection MPOs to an MPS.
+
+The result has zero amplitude on basis states rejected by any projection, while
+keeping the original unprimed site indices so it can be used as a DMRG input
+state.
+"""
+function project_state(psi::ITensorMPS.MPS, projections; cutoff=1e-8, kwargs...)
+  projection_tuple = projection_sequence(projections)
+  target_sites = projection_target_sites(psi)
+  validate_projection_sequence(target_sites, projection_tuple)
+
+  projected = psi
+  for P in projection_tuple
+    projected = ITensors.apply(P, projected; cutoff, kwargs...)
+  end
+
+  return projected
+end
+
+projection_sequence(projection::ITensorMPS.MPO) = (projection,)
+projection_sequence(projections::Tuple{Vararg{ITensorMPS.MPO}}) = projections
+projection_sequence(projections::AbstractVector{<:ITensorMPS.MPO}) = Tuple(projections)
+
+projection_target_sites(H::ITensorMPS.MPO) = ITensorMPS.siteinds(first, H; plev=0)
+projection_target_sites(psi::ITensorMPS.MPS) = ITensorMPS.siteinds(psi)
+
+function validate_projection_sequence(target_sites, projections)
+  for (i, P) in enumerate(projections)
+    if length(P) != length(target_sites)
+      msg = "projection MPO $(i) has length $(length(P)); expected $(length(target_sites))"
+      throw(DimensionMismatch(msg))
+    end
+
+    projection_sites = ITensorMPS.siteinds(first, P; plev=0)
+    if projection_sites != target_sites
+      msg = "projection MPO $(i) must share the target's unprimed site indices"
+      throw(DimensionMismatch(msg))
+    end
+  end
+end
+
 
 ##############################################
 # Generic constraint construction path

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -261,12 +261,18 @@ end
 projection_mpos(constraints::AbstractVector{<:AbstractConstraint}, sites) =
   projection_mpos(Float64, constraints, sites)
 
-# Apply one or more diagonal projection MPOs to a Hamiltonian MPO. For
-# projection MPOs P, this builds the CoTenN-style effective Hamiltonian P' H P.
-# The projection MPOs produced above are real diagonal projectors, so the
-# implementation composes them as P H P using ITensorMPS.apply to restore the
-# unprimed/primed site-index structure expected by DMRG. The resulting bond
-# dimension can grow with the product of H's links and the projection links.
+"""
+    project_hamiltonian(H, projections; cutoff=1e-8, kwargs...)
+
+Apply one or more diagonal projection MPOs to a Hamiltonian MPO.
+
+For projection MPOs `P`, this builds the CoTenN-style effective Hamiltonian
+`P' * H * P`. The projection MPOs produced by [`projection_mpo`](@ref) are
+real diagonal projectors, so the implementation composes them as `P * H * P`
+using ITensorMPS' `apply` helper to contract the MPOs and restore the usual
+unprimed/primed site-index structure expected by DMRG. The resulting bond
+dimension can grow with the product of `H`'s links and the projection links.
+"""
 function project_hamiltonian(H::ITensorMPS.MPO, projections; cutoff=1e-8, kwargs...)
   projection_tuple = projection_sequence(projections)
   target_sites = projection_target_sites(H)
@@ -281,9 +287,15 @@ function project_hamiltonian(H::ITensorMPS.MPO, projections; cutoff=1e-8, kwargs
   return H_eff
 end
 
-# Apply one or more diagonal projection MPOs to an MPS. The result has zero
-# amplitude on basis states rejected by any projection, while keeping the
-# original unprimed site indices so it can be used as a DMRG input state.
+"""
+    project_state(psi, projections; cutoff=1e-8, kwargs...)
+
+Apply one or more diagonal projection MPOs to an MPS.
+
+The result has zero amplitude on basis states rejected by any projection, while
+keeping the original unprimed site indices so it can be used as a DMRG input
+state.
+"""
 function project_state(psi::ITensorMPS.MPS, projections; cutoff=1e-8, kwargs...)
   projection_tuple = projection_sequence(projections)
   target_sites = projection_target_sites(psi)

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -261,18 +261,12 @@ end
 projection_mpos(constraints::AbstractVector{<:AbstractConstraint}, sites) =
   projection_mpos(Float64, constraints, sites)
 
-"""
-    project_hamiltonian(H, projections; cutoff=1e-8, kwargs...)
-
-Apply one or more diagonal projection MPOs to a Hamiltonian MPO.
-
-For projection MPOs `P`, this builds the CoTenN-style effective Hamiltonian
-`P' * H * P`. The projection MPOs produced by [`projection_mpo`](@ref) are
-real diagonal projectors, so the implementation composes them as `P * H * P`
-using ITensorMPS' `apply` helper to contract the MPOs and restore the usual
-unprimed/primed site-index structure expected by DMRG. The resulting bond
-dimension can grow with the product of `H`'s links and the projection links.
-"""
+# Apply one or more diagonal projection MPOs to a Hamiltonian MPO. For
+# projection MPOs P, this builds the CoTenN-style effective Hamiltonian P' H P.
+# The projection MPOs produced above are real diagonal projectors, so the
+# implementation composes them as P H P using ITensorMPS.apply to restore the
+# unprimed/primed site-index structure expected by DMRG. The resulting bond
+# dimension can grow with the product of H's links and the projection links.
 function project_hamiltonian(H::ITensorMPS.MPO, projections; cutoff=1e-8, kwargs...)
   projection_tuple = projection_sequence(projections)
   target_sites = projection_target_sites(H)
@@ -287,15 +281,9 @@ function project_hamiltonian(H::ITensorMPS.MPO, projections; cutoff=1e-8, kwargs
   return H_eff
 end
 
-"""
-    project_state(psi, projections; cutoff=1e-8, kwargs...)
-
-Apply one or more diagonal projection MPOs to an MPS.
-
-The result has zero amplitude on basis states rejected by any projection, while
-keeping the original unprimed site indices so it can be used as a DMRG input
-state.
-"""
+# Apply one or more diagonal projection MPOs to an MPS. The result has zero
+# amplitude on basis states rejected by any projection, while keeping the
+# original unprimed site indices so it can be used as a DMRG input state.
 function project_state(psi::ITensorMPS.MPS, projections; cutoff=1e-8, kwargs...)
   projection_tuple = projection_sequence(projections)
   target_sites = projection_target_sites(psi)

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -267,11 +267,8 @@ projection_mpos(constraints::AbstractVector{<:AbstractConstraint}, sites) =
 Apply one or more diagonal projection MPOs to a Hamiltonian MPO.
 
 For projection MPOs `P`, this builds the CoTenN-style effective Hamiltonian
-`P' * H * P`. The projection MPOs produced by [`projection_mpo`](@ref) are
-real diagonal projectors, so the implementation composes them as `P * H * P`
-using ITensorMPS' `apply` helper to contract the MPOs and restore the usual
-unprimed/primed site-index structure expected by DMRG. The resulting bond
-dimension can grow with the product of `H`'s links and the projection links.
+`P' * H * P`. The resulting bond dimension can grow with the product of
+`H`'s links and the projection links.
 """
 function project_hamiltonian(H::ITensorMPS.MPO, projections; cutoff=1e-8, kwargs...)
   projection_tuple = projection_sequence(projections)
@@ -280,7 +277,7 @@ function project_hamiltonian(H::ITensorMPS.MPO, projections; cutoff=1e-8, kwargs
 
   H_eff = H
   for P in projection_tuple
-    H_eff = ITensors.apply(P, H_eff; cutoff, kwargs...)
+    H_eff = ITensors.apply(ITensors.dag(P), H_eff; cutoff, kwargs...)
     H_eff = ITensors.apply(H_eff, P; cutoff, kwargs...)
   end
 
@@ -292,9 +289,9 @@ end
 
 Apply one or more diagonal projection MPOs to an MPS.
 
-The result has zero amplitude on basis states rejected by any projection, while
-keeping the original unprimed site indices so it can be used as a DMRG input
-state.
+The result has zero amplitude on basis states rejected by any projection,
+while keeping the original unprimed site indices
+so it can be used as a DMRG input state.
 """
 function project_state(psi::ITensorMPS.MPS, projections; cutoff=1e-8, kwargs...)
   projection_tuple = projection_sequence(projections)

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -8,6 +8,17 @@ function mpo_diagonal(H, sites, bits)
   return real(ITensors.inner(psi', H, psi))
 end
 
+function mpo_matrix_element(H, sites, bra_bits, ket_bits)
+  bra = ITensorMPS.MPS(sites, string.(bra_bits))
+  ket = ITensorMPS.MPS(sites, string.(ket_bits))
+  return real(ITensors.inner(bra', H, ket))
+end
+
+function mps_amplitude(psi, sites, bits)
+  basis = ITensorMPS.MPS(sites, string.(bits))
+  return real(ITensors.inner(basis, psi))
+end
+
 function assert_projection_matches_feasibility(constraint, sites)
   H = TenSolver.projection_mpo(constraint, sites)
 
@@ -136,6 +147,73 @@ end
 
     for constraint in TEST_CONSTRAINTS
       assert_projection_matches_feasibility(constraint, sites)
+    end
+  end
+
+  @testset "Projected Hamiltonian and state utilities" begin
+    Q = [
+       1.0   0.25 -0.50
+       0.25 -2.00  0.75
+      -0.50  0.75  3.00
+    ]
+    H = TenSolver.tensorize(Q)
+    sites = ITensorMPS.siteinds(first, H; plev=0)
+
+    constraints = AbstractConstraint[
+      NotEqualsConstraint([1, 2], [1, 1]),
+      ExactlyOneConstraint([1, 3], 0),
+    ]
+    projections = TenSolver.projection_mpos(constraints, sites)
+
+    @test ITensorMPS.maxlinkdim(projections[1]) <= 2
+
+    H_eff = TenSolver.project_hamiltonian(H, projections; cutoff=1e-12)
+    expected_maxlink = ITensorMPS.maxlinkdim(H) * prod(ITensorMPS.maxlinkdim, projections)
+    @test ITensorMPS.maxlinkdim(H_eff) <= expected_maxlink
+
+    psi = ITensorMPS.MPS(sites, fill("full", length(sites)))
+    projected_psi = TenSolver.project_state(psi, projections; cutoff=1e-12)
+
+    @test ITensorMPS.siteinds(first, H_eff; plev=0) == sites
+    @test ITensorMPS.siteinds(first, H_eff; plev=1) == ITensors.prime.(sites)
+    @test all(isempty, ITensorMPS.siteinds(all, H_eff; plev=2))
+    @test ITensorMPS.siteinds(projected_psi) == sites
+
+    for bra_bits in all_bitstrings(sites), ket_bits in all_bitstrings(sites)
+      bra_feasible = is_feasible(collect(bra_bits), constraints)
+      ket_feasible = is_feasible(collect(ket_bits), constraints)
+      expected = bra_feasible && ket_feasible ?
+        mpo_matrix_element(H, sites, bra_bits, ket_bits) :
+        0.0
+
+      @test mpo_matrix_element(H_eff, sites, bra_bits, ket_bits) ≈ expected atol=1e-10
+    end
+
+    for bits in all_bitstrings(sites)
+      expected = is_feasible(collect(bits), constraints) ?
+        mps_amplitude(psi, sites, bits) :
+        0.0
+
+      @test mps_amplitude(projected_psi, sites, bits) ≈ expected atol=1e-10
+    end
+  end
+
+  @testset "Infeasible projections remain zero" begin
+    H = TenSolver.tensorize([1.0 0.5; 0.5 2.0])
+    sites = ITensorMPS.siteinds(first, H; plev=0)
+    impossible = SumConstraint([1, 2], [1, 1], :(==), 3)
+    P = TenSolver.projection_mpo(impossible, sites)
+
+    H_eff = TenSolver.project_hamiltonian(H, P; cutoff=1e-12)
+    psi = ITensorMPS.MPS(sites, fill("full", length(sites)))
+    projected_psi = TenSolver.project_state(psi, P; cutoff=1e-12)
+
+    for bra_bits in all_bitstrings(sites), ket_bits in all_bitstrings(sites)
+      @test mpo_matrix_element(H_eff, sites, bra_bits, ket_bits) == 0.0
+    end
+
+    for bits in all_bitstrings(sites)
+      @test mps_amplitude(projected_psi, sites, bits) == 0.0
     end
   end
 

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -8,17 +8,6 @@ function mpo_diagonal(H, sites, bits)
   return real(ITensors.inner(psi', H, psi))
 end
 
-function mpo_matrix_element(H, sites, bra_bits, ket_bits)
-  bra = ITensorMPS.MPS(sites, string.(bra_bits))
-  ket = ITensorMPS.MPS(sites, string.(ket_bits))
-  return real(ITensors.inner(bra', H, ket))
-end
-
-function mps_amplitude(psi, sites, bits)
-  basis = ITensorMPS.MPS(sites, string.(bits))
-  return real(ITensors.inner(basis, psi))
-end
-
 function assert_projection_matches_feasibility(constraint, sites)
   H = TenSolver.projection_mpo(constraint, sites)
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -27,3 +27,14 @@ function brute_force(f::Function, T, n::Int64)
 
   return min_now, solution
 end
+
+function mpo_matrix_element(H, sites, bra_bits, ket_bits)
+  bra = ITensorMPS.MPS(sites, string.(bra_bits))
+  ket = ITensorMPS.MPS(sites, string.(ket_bits))
+  return real(ITensors.inner(bra', H, ket))
+end
+
+function mps_amplitude(psi, sites, bits)
+  basis = ITensorMPS.MPS(sites, string.(bits))
+  return real(ITensors.inner(basis, psi))
+end


### PR DESCRIPTION
## Summary

- Add internal `project_hamiltonian` and `project_state` helpers for applying projection MPOs to DMRG Hamiltonians and initial states.
- Use ITensorMPS `apply` contractions so projected MPO/MPS results keep DMRG-compatible site prime levels.
- Validate that projection MPOs share the target's unprimed site indices before composition.
- Add dense small-system tests for `P' * H * P` masking, projected-state amplitudes, infeasible all-zero projections, and bond-dimension/prime-level expectations.

## Tests

- `git diff --check`
- `julia +1.12 --project=test -e 'push!(LOAD_PATH, pwd()); using Test, Random, LinearAlgebra, TenSolver; include("test/projection_mpo.jl")'`
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test(; coverage=false)'`

Note: the full package test re-resolved into a temporary Julia 1.12 test environment because the checked-in manifest was resolved with Julia 1.10.11.

## Branch Hygiene

- Base branch: `main`
- Source branch point: refreshed `origin/main` after #60 merged via PR #91
- Stacked status: unstacked; this PR targets default `main`
- Prerequisites: #58, #59, and #60 are already integrated into `main`

Closes #61
