### PR TITLE
Add constrained solving to minimize and maximize

### DIFF
--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -42,8 +42,6 @@ Backend-specific keyword arguments:
   Defaults to `AbstractConstraint[]`. In constrained DMRG solves, TenSolver lowers each constraint to
   a projection MPO, solves the projected Hamiltonian, and returns a feasible sampled bitstring.
   For polynomial objectives, constraints are expressed in the same order as their `effective_variables`.
-- `feasible_sample_retries :: Int` - Maximum attempts to draw a feasible bitstring from a constrained
-  final state before throwing a diagnostic error. Defaults to `100`.
 - `maxdim` - The maximum allowed bond dimension.
   Integer or array of integer specifying the bond dimension per iteration.
   You can use this keyword to control the solver's accuracy vs resources trade-off.
@@ -103,9 +101,9 @@ end
 # semantic zero-operator test after arbitrary MPO algebra.
 is_zero_mpo(H::MPO; cutoff=0) = norm(H) < cutoff
 
-expectation(H::MPO, x::MPS) = inner(x', H, x)
+expectation(H::MPO, x::MPS) = real(inner(x', H, x))
 
-variance(H::MPO, x::MPS) = real(inner(H, x, H, x) - expectation(H, x)^2)
+variance(H::MPO, x::MPS) = real(inner(H, x, H, x)) - expectation(H, x)^2
 
 # Strict upper triangular part of an array
 function upper_indices(a)
@@ -231,11 +229,8 @@ function minimize_mpo( H :: MPO
                      , on_iteration     :: Union{Nothing, Function} = nothing
                      , callback_every   :: Int = 1
                      , permutation :: Vector{Int} = collect(1:length(H))
-                     , feasible_sample_retries :: Integer = 100
                      ) where {T}
   callback_every >= 1 || throw(ArgumentError("`callback_every` must be >= 1, got $callback_every"))
-  feasible_sample_retries >= 1 ||
-    throw(ArgumentError("`feasible_sample_retries` must be >= 1, got $feasible_sample_retries"))
   initial_time      = time()
   energies_log      = T[]
   bond_dims_log     = Int[]
@@ -299,7 +294,7 @@ function minimize_mpo( H :: MPO
         error_type=ErrorException,
         message="constrained DMRG produced a state with zero feasible amplitude; constraints may be infeasible or the projection cutoff may be too large",
       )
-      energy = real(expectation(H, psi))
+      energy = expectation(H, psi)
     end
 
     # Get metadata #
@@ -383,15 +378,15 @@ function groundstate(H::MPO, psi0::MPS; projections=(), cutoff=1e-8, kwargs...)
     ))
   end
 
-  energies = map(b -> real(expectation(H, b)), candidates)
+  energies = map(b -> expectation(H, b), candidates)
   emin = minimum(energies)
 
   # Degenerate feasible states: return their uniform superposition so sampling
   # is unbiased (preserves the previous unconstrained n=1 behavior).
   if length(candidates) == 2 && all(≈(emin), energies)
     return emin, ITensorMPS.MPS(sites, ["full"])
+  else
+    i = argmin(energies)
+    return energies[i], candidates[i]
   end
-
-  i = argmin(energies)
-  return energies[i], candidates[i]
 end

--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -11,9 +11,6 @@ ITensors.op(::OpName"D",::SiteType"Qudit", d::Int) = diagm(0:(d-1))
 
 ITensors.state(::StateName"full", ::SiteType"Qudit", s::ITensorMPS.Index) = (d = dim(s); fill(1/sqrt(d), d))
 
-expectation(H, x) = inner(x', H, x)
-variance(H::MPO, x::MPS) = real(inner(H, x, H, x) - expectation(H, x)^2)
-
 #----------------------------------------------------------#
 # Interface                                                #
 #----------------------------------------------------------#
@@ -69,32 +66,13 @@ function minimize(
   ;
   cutoff=1e-8,
   preprocess::Bool=false,
-  constraints=AbstractConstraint[],
   kwargs...,
 ) where T
-  constraint_vec = normalize_constraints(constraints)
   Qp, lp, permutation = preprocess ? preprocess_qubo(Q, l, cutoff) : (Q, l, collect(1:size(Q, 1)))
   H      = tensorize(Qp, isnothing(lp) ? diag(Qp) : diag(Qp) + lp; cutoff)
   obj(x) = dot(x, Q, x) + c + maybe(l -> dot(l,x), l; default=zero(T))
 
-  if isempty(constraint_vec)
-    return minimize_mpo(H, c, obj; cutoff, permutation, kwargs...)
-  end
-
-  tensor_constraints = constraint_reindex(constraint_vec, permutation)
-  H_eff, initial_state, projections = constrained_projection_problem(T, H, tensor_constraints; cutoff)
-
-  return minimize_mpo(
-    H_eff,
-    c,
-    obj;
-    cutoff,
-    permutation,
-    initial_state,
-    solution_projection=projections,
-    sample_validator=x -> is_feasible(x, constraint_vec),
-    kwargs...,
-  )
+  return minimize_mpo(H, c, obj ; cutoff, permutation, kwargs...)
 end
 
 """
@@ -107,28 +85,13 @@ Solve the Polynomial Unconstrained Binary Optimization problem
 
 See also [`maximize`](@ref).
 """
-function minimize(::DMRGBackend, p::AbstractPolynomial{T}; cutoff=1e-8, constraints=AbstractConstraint[], kwargs...) where T
-  constraint_vec = normalize_constraints(constraints)
-  H   = tensorize(p)
-  cte = constant(p)
-  vs = variables(p)
+function minimize(::DMRGBackend, p::AbstractPolynomial{T}; cutoff=1e-8, kwargs...) where T
+  H      = tensorize(p)
+  cte    = constant_term(p)
+  vs     = variables(p)
+  obj(x) = p(vs => x)
 
-  if isempty(constraint_vec)
-    return minimize_mpo(H, cte, a -> p(vs => a); cutoff, kwargs...)
-  end
-
-  H_eff, initial_state, projections = constrained_projection_problem(T, H, constraint_vec; cutoff)
-
-  return minimize_mpo(
-    H_eff,
-    cte,
-    a -> p(vs => a);
-    cutoff,
-    initial_state,
-    solution_projection=projections,
-    sample_validator=x -> is_feasible(x, constraint_vec),
-    kwargs...,
-  )
+  return minimize_mpo(H, cte, obj ; cutoff, kwargs...)
 end
 
 
@@ -136,29 +99,27 @@ end
 # The actual computations                                  #
 #----------------------------------------------------------#
 
-function normalize_constraints(constraints)
-  return collect(AbstractConstraint, constraints)
-end
-
-function constrained_projection_problem(::Type{T}, H, constraints; cutoff) where {T}
-  sites = ITensorMPS.siteinds(first, H; plev=0)
-  projections = projection_mpos(T, constraints, sites)
-  initial_state = constrained_initial_state(sites, projections; cutoff)
-  H_eff = is_zero_mpo(H; cutoff) ? H : project_hamiltonian(H, projections; cutoff)
-
-  @debug(
-    "Constraint projection MPO construction finished",
-    projection_max_bond=map(ITensorMPS.maxlinkdim, projections),
-    projected_hamiltonian_max_bond=ITensorMPS.maxlinkdim(H_eff),
-    projected_initial_max_bond=ITensorMPS.maxlinkdim(initial_state),
-  )
-
-  return H_eff, initial_state, projections
-end
-
 # Structural check for freshly tensorized zero objectives; this is not a
 # semantic zero-operator test after arbitrary MPO algebra.
 is_zero_mpo(H::MPO; cutoff=0) = norm(H) < cutoff
+
+expectation(H::MPO, x::MPS) = inner(x', H, x)
+
+variance(H::MPO, x::MPS) = real(inner(H, x, H, x) - expectation(H, x)^2)
+
+# Strict upper triangular part of an array
+function upper_indices(a)
+  return (Tuple(ci)
+            for ci in CartesianIndices(size(a))
+            if issorted(Tuple(ci); lt = (<=)))
+end
+
+function constant_term(p::AbstractPolynomial{T}) where T
+  ts  = terms(p)
+  idx = findfirst(isconstant, ts)
+
+  return isnothing(idx) ? zero(T) : coefficient(ts[idx])
+end
 
 function constrained_initial_state(sites, projections; cutoff)
   psi = ITensorMPS.MPS(sites, fill("full", length(sites)))
@@ -179,39 +140,6 @@ function project_feasible_state(psi::MPS, projections; cutoff, error_type, messa
   end
 
   return normalize(projected)
-end
-
-function sampled_objective(dist, obj; sample_validator, feasible_sample_retries)
-  feasible_sample_retries >= 1 ||
-    throw(ArgumentError("`feasible_sample_retries` must be >= 1, got $feasible_sample_retries"))
-
-  if isnothing(sample_validator)
-    return obj(sample(dist))
-  end
-
-  local last_sample
-  for _ in 1:feasible_sample_retries
-    x = sample(dist)
-    sample_validator(x) && return obj(x)
-    last_sample = x
-  end
-
-  throw(ErrorException("failed to sample a feasible constrained solution after $(feasible_sample_retries) attempts; last sample was $(last_sample)"))
-end
-
-
-# Strict upper triangular part of an array
-function upper_indices(a)
-  return (Tuple(ci)
-            for ci in CartesianIndices(size(a))
-            if issorted(Tuple(ci); lt = (<=)))
-end
-
-function constant(p::AbstractPolynomial{T}) where T
-  ts  = terms(p)
-  idx = findfirst(isconstant, ts)
-
-  return isnothing(idx) ? zero(T) : coefficient(ts[idx])
 end
 
 
@@ -285,11 +213,11 @@ function single_variable_minimize(
   verbosity,
   on_iteration,
   callback_every,
-  sample_validator=nothing,
+  constraints,
 ) where {T}
   feasible_samples = [
     x for x in ([0], [1])
-    if isnothing(sample_validator) || sample_validator(x)
+    if is_feasible(x, constraints)
   ]
 
   if isempty(feasible_samples)
@@ -325,9 +253,10 @@ end
 function minimize_mpo( H :: MPO
                      , c :: T
                      , obj
-                     ; device     :: Function = cpu
-                     , cutoff     = 1e-8  #  a cutoff of 1E-5 gives sensible accuracy; a cutoff of 1E-8 is high accuracy; and a cutoff of 1E-12 is near exact accuracy. (https://itensor.org/docs.cgi?page=tutorials/dmrg_params)
-                     , verbosity  = 1
+                     ; device      = cpu
+                     , cutoff      = 1e-8  #  a cutoff of 1E-5 gives sensible accuracy; a cutoff of 1E-8 is high accuracy; and a cutoff of 1E-12 is near exact accuracy. (https://itensor.org/docs.cgi?page=tutorials/dmrg_params)
+                     , verbosity   = 1
+                     , constraints = AbstractConstraint[]
                      # Stopping criteria
                      , iterations :: Union{Nothing, Int} = nothing
                      , time_limit = +Inf
@@ -342,12 +271,9 @@ function minimize_mpo( H :: MPO
                      , eigsolve_maxiter   :: Int     = 2
                      , eigsolve_tol       :: Float64 = 1e-14
                      # Iteration callback
-                     , on_iteration :: Union{Nothing, Function} = nothing
+                     , on_iteration     :: Union{Nothing, Function} = nothing
                      , callback_every   :: Int = 1
                      , permutation :: Vector{Int} = Int[]
-                     , initial_state :: Union{Nothing, MPS} = nothing
-                     , solution_projection = nothing
-                     , sample_validator = nothing
                      , feasible_sample_retries :: Integer = 100
                      ) where {T}
   callback_every >= 1 || throw(ArgumentError("`callback_every` must be >= 1, got $callback_every"))
@@ -361,7 +287,18 @@ function minimize_mpo( H :: MPO
   # Quantization
   sites = ITensorMPS.siteinds(first, H; plev=0)
   solution_permutation = isempty(permutation) ? collect(1:length(sites)) : permutation
-  solution_projections = isnothing(solution_projection) ? nothing : map(device, projection_sequence(solution_projection))
+
+  # Constraints
+  constraints  = constraint_reindex(collect(AbstractConstraint, constraints), permutation)
+  projections  = projection_mpos(T, constraints, sites)
+  H_eff = is_zero_mpo(H; cutoff) ? H : project_hamiltonian(H, projections; cutoff)
+
+  # Initial state
+  psi = if isempty(constraints)
+          ITensorMPS.random_mps(T, sites; linkdims=inidim)
+        else
+          constrained_initial_state(sites, projections; cutoff)
+        end
 
   if length(sites) == 1
     return single_variable_minimize(
@@ -373,18 +310,25 @@ function minimize_mpo( H :: MPO
       verbosity,
       on_iteration,
       callback_every,
-      sample_validator,
+      constraints
     )
   end
 
-  H     = device(H)
-  psi   = isnothing(initial_state) ? ITensorMPS.random_mps(T, sites; linkdims=inidim) : initial_state
+  @debug(
+    "Constraint projection MPO construction finished",
+    projection_max_bond = map(ITensorMPS.maxlinkdim, projections),
+    projected_hamiltonian_max_bond = ITensorMPS.maxlinkdim(H_eff),
+    projected_initial_max_bond = ITensorMPS.maxlinkdim(psi),
+  )
+
+  # GPU acceleration
+  H     = device(H_eff)
   psi   = device(psi)
+  projections = map(device, projections)
 
   @debug("MPO construction finished",
     time=(time() - initial_time),
     max_bond = ITensorMPS.maxlinkdim(H),
-    num_coefficients = sum(prod(m) for m in H),
   )
 
   iterlog_header(verbosity)
@@ -406,10 +350,10 @@ function minimize_mpo( H :: MPO
                       , eigsolve_verbosity = 0
                  )
 
-    if !isnothing(solution_projections)
+    if !isempty(projections)
       psi = project_feasible_state(
         psi,
-        solution_projections;
+        projections;
         cutoff,
         error_type=ErrorException,
         message="constrained DMRG produced a state with zero feasible amplitude; constraints may be infeasible or the projection cutoff may be too large",
@@ -463,12 +407,7 @@ function minimize_mpo( H :: MPO
   # The calculated energy has approximation errors compared to the true solution.
   # It makes more sense to sample a solution and calculate the true objective function applied to it.
   dist = Solution{T}(psi, energies_log, bond_dims_log, elapsed_times_log, solution_permutation)
-  optimal = sampled_objective(
-    dist,
-    obj;
-    sample_validator,
-    feasible_sample_retries,
-  )
+  optimal = obj(sample(dist))
   elapsed_time = time() - initial_time
 
   iterlog_footer(verbosity, optimal, elapsed_time)

--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -41,6 +41,12 @@ where D_i acts locally on the i-th qubit as [0 0; 0 1], i.e, the projection on |
 
 Backend-specific keyword arguments:
 
+- `constraints :: AbstractVector{<:AbstractConstraint}` - Experimental native Julia hard constraints.
+  Defaults to `AbstractConstraint[]`. In constrained DMRG solves, TenSolver lowers each constraint to
+  a projection MPO, solves the projected Hamiltonian, and returns a feasible sampled bitstring.
+  For polynomial objectives, constraints are expressed in the same order as their `effective_variables`.
+- `feasible_sample_retries :: Int` - Maximum attempts to draw a feasible bitstring from a constrained
+  final state before throwing a diagnostic error. Defaults to `100`.
 - `maxdim` - The maximum allowed bond dimension.
   Integer or array of integer specifying the bond dimension per iteration.
   You can use this keyword to control the solver's accuracy vs resources trade-off.
@@ -75,7 +81,7 @@ function minimize(
     return minimize_mpo(H, c, obj; cutoff, permutation, kwargs...)
   end
 
-  tensor_constraints = tensor_order_constraints(constraint_vec, permutation)
+  tensor_constraints = constraint_reindex(constraint_vec, permutation)
   H_eff, initial_state, projections = constrained_projection_problem(T, H, tensor_constraints; cutoff)
 
   return minimize_mpo(
@@ -131,72 +137,14 @@ end
 #----------------------------------------------------------#
 
 function normalize_constraints(constraints)
-  constraints isa AbstractVector ||
-    throw(ArgumentError("`constraints` must be an AbstractVector of AbstractConstraint values"))
-
-  constraint_vec = AbstractConstraint[]
-  for (i, constraint) in pairs(constraints)
-    constraint isa AbstractConstraint ||
-      throw(ArgumentError("constraints[$i] must be an AbstractConstraint, got $(typeof(constraint))"))
-    push!(constraint_vec, constraint)
-  end
-
-  return constraint_vec
-end
-
-function tensor_order_constraints(constraints::AbstractVector{<:AbstractConstraint}, permutation)
-  is_identity_permutation(permutation) && return constraints
-
-  original_to_tensor = invperm(permutation)
-  return AbstractConstraint[
-    tensor_order_constraint(constraint, original_to_tensor)
-    for constraint in constraints
-  ]
-end
-
-function tensor_site(site, original_to_tensor)
-  checkbounds(original_to_tensor, site)
-  return original_to_tensor[site]
-end
-
-function tensor_order_constraint(constraint::SumConstraint, original_to_tensor)
-  sites = constraint_sites(constraint)
-  return SumConstraint(
-    [tensor_site(site, original_to_tensor) for site in sites],
-    [constraint.weights[site] for site in sites],
-    constraint.relation,
-    constraint.rhs,
-  )
-end
-
-function tensor_order_constraint(constraint::NotEqualsConstraint, original_to_tensor)
-  sites = constraint_sites(constraint)
-  return NotEqualsConstraint(
-    [tensor_site(site, original_to_tensor) for site in sites],
-    [constraint.values[site] for site in sites],
-  )
-end
-
-function tensor_order_constraint(constraint::ExactlyOneConstraint, original_to_tensor)
-  return ExactlyOneConstraint(
-    [tensor_site(site, original_to_tensor) for site in constraint.sites],
-    constraint.value,
-  )
-end
-
-function tensor_order_constraint(constraint::RelationConstraint, original_to_tensor)
-  return RelationConstraint(
-    tensor_site(constraint.left_site, original_to_tensor),
-    constraint.relation,
-    tensor_site(constraint.right_site, original_to_tensor),
-  )
+  return collect(AbstractConstraint, constraints)
 end
 
 function constrained_projection_problem(::Type{T}, H, constraints; cutoff) where {T}
   sites = ITensorMPS.siteinds(first, H; plev=0)
   projections = projection_mpos(T, constraints, sites)
   initial_state = constrained_initial_state(sites, projections; cutoff)
-  H_eff = is_zero_mpo(H) ? H : project_hamiltonian(H, projections; cutoff)
+  H_eff = is_zero_mpo(H; cutoff) ? H : project_hamiltonian(H, projections; cutoff)
 
   @debug(
     "Constraint projection MPO construction finished",
@@ -210,7 +158,7 @@ end
 
 # Structural check for freshly tensorized zero objectives; this is not a
 # semantic zero-operator test after arbitrary MPO algebra.
-is_zero_mpo(H::MPO) = all(iszero, H)
+is_zero_mpo(H::MPO; cutoff=0) = norm(H) < cutoff
 
 function constrained_initial_state(sites, projections; cutoff)
   psi = ITensorMPS.MPS(sites, fill("full", length(sites)))

--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -247,7 +247,7 @@ function minimize_mpo( H :: MPO
   # Constraints
   projections = map(
     device,
-    projection_mpos(T, constraints, sites, permutation),
+    projection_mpos(T, constraints, sites; permutation),
   )
 
   # Hamiltonian construction
@@ -262,11 +262,7 @@ function minimize_mpo( H :: MPO
     projection_max_bond = map(ITensorMPS.maxlinkdim, projections),
     projected_hamiltonian_max_bond = ITensorMPS.maxlinkdim(H),
     projected_initial_max_bond = ITensorMPS.maxlinkdim(psi),
-  )
-
-  @debug("MPO construction finished",
     time=(time() - initial_time),
-    max_bond = ITensorMPS.maxlinkdim(H),
   )
 
   iterlog_header(verbosity)

--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -208,6 +208,8 @@ function constrained_projection_problem(::Type{T}, H, constraints; cutoff) where
   return H_eff, initial_state, projections
 end
 
+# Structural check for freshly tensorized zero objectives; this is not a
+# semantic zero-operator test after arbitrary MPO algebra.
 is_zero_mpo(H::MPO) = all(iszero, H)
 
 function constrained_initial_state(sites, projections; cutoff)
@@ -326,18 +328,33 @@ function tensorize(p::AbstractPolynomial{T}; cutoff = zero(T)) where T
 end
 
 
-function single_variable_minimize(::Type{T}, sites, obj, initial_time; device, verbosity, on_iteration, callback_every) where {T}
-  x0 = [0]
-  x1 = [1]
-  e0 = obj(x0)
-  e1 = obj(x1)
+function single_variable_minimize(
+  ::Type{T},
+  sites,
+  obj,
+  initial_time;
+  device,
+  verbosity,
+  on_iteration,
+  callback_every,
+  sample_validator=nothing,
+) where {T}
+  feasible_samples = [
+    x for x in ([0], [1])
+    if isnothing(sample_validator) || sample_validator(x)
+  ]
 
-  energy, state = if e0 == e1
-    (T(e0), ["full"])
-  elseif e0 < e1
-    (T(e0), string.(x0))
+  if isempty(feasible_samples)
+    throw(ArgumentError("constraints define an empty feasible subspace; no binary vector satisfies all constraints"))
+  end
+
+  feasible_values = [obj(x) for x in feasible_samples]
+
+  energy, state = if length(feasible_samples) == 2 && feasible_values[1] == feasible_values[2]
+    (T(feasible_values[1]), ["full"])
   else
-    (T(e1), string.(x1))
+    idx = argmin(feasible_values)
+    (T(feasible_values[idx]), string.(feasible_samples[idx]))
   end
 
   psi = ITensorMPS.MPS(sites, state) |> device
@@ -398,8 +415,18 @@ function minimize_mpo( H :: MPO
   solution_permutation = isempty(permutation) ? collect(1:length(sites)) : permutation
   solution_projections = isnothing(solution_projection) ? nothing : map(device, projection_sequence(solution_projection))
 
-  if length(sites) == 1 && isnothing(initial_state) && isnothing(solution_projections)
-    return single_variable_minimize(T, sites, obj, initial_time; device, verbosity, on_iteration, callback_every)
+  if length(sites) == 1
+    return single_variable_minimize(
+      T,
+      sites,
+      obj,
+      initial_time;
+      device,
+      verbosity,
+      on_iteration,
+      callback_every,
+      sample_validator,
+    )
   end
 
   H     = device(H)

--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -230,7 +230,7 @@ function minimize_mpo( H :: MPO
                      # Iteration callback
                      , on_iteration     :: Union{Nothing, Function} = nothing
                      , callback_every   :: Int = 1
-                     , permutation :: Vector{Int} = Int[]
+                     , permutation :: Vector{Int} = collect(1:length(H))
                      , feasible_sample_retries :: Integer = 100
                      ) where {T}
   callback_every >= 1 || throw(ArgumentError("`callback_every` must be >= 1, got $callback_every"))
@@ -243,11 +243,12 @@ function minimize_mpo( H :: MPO
 
   # Quantization
   sites = ITensorMPS.siteinds(first, H; plev=0)
-  solution_permutation = isempty(permutation) ? collect(1:length(sites)) : permutation
 
   # Constraints
-  constraints = constraint_reindex(collect(AbstractConstraint, constraints), permutation)
-  projections = map(device, projection_mpos(T, constraints, sites))
+  projections = map(
+    device,
+    projection_mpos(T, constraints, sites, permutation),
+  )
 
   # Hamiltonian construction
   H = device(H)
@@ -353,7 +354,7 @@ function minimize_mpo( H :: MPO
 
   # The calculated energy has approximation errors compared to the true solution.
   # It makes more sense to sample a solution and calculate the true objective function applied to it.
-  dist = Solution{T}(psi, energies_log, bond_dims_log, elapsed_times_log, solution_permutation)
+  dist = Solution{T}(psi, energies_log, bond_dims_log, elapsed_times_log, permutation)
   optimal = obj(sample(dist))
   elapsed_time = time() - initial_time
 

--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -63,13 +63,32 @@ function minimize(
   ;
   cutoff=1e-8,
   preprocess::Bool=false,
+  constraints=AbstractConstraint[],
   kwargs...,
 ) where T
+  constraint_vec = normalize_constraints(constraints)
   Qp, lp, permutation = preprocess ? preprocess_qubo(Q, l, cutoff) : (Q, l, collect(1:size(Q, 1)))
   H      = tensorize(Qp, isnothing(lp) ? diag(Qp) : diag(Qp) + lp; cutoff)
   obj(x) = dot(x, Q, x) + c + maybe(l -> dot(l,x), l; default=zero(T))
 
-  return minimize_mpo(H, c, obj; cutoff, permutation, kwargs...)
+  if isempty(constraint_vec)
+    return minimize_mpo(H, c, obj; cutoff, permutation, kwargs...)
+  end
+
+  tensor_constraints = tensor_order_constraints(constraint_vec, permutation)
+  H_eff, initial_state, projections = constrained_projection_problem(T, H, tensor_constraints; cutoff)
+
+  return minimize_mpo(
+    H_eff,
+    c,
+    obj;
+    cutoff,
+    permutation,
+    initial_state,
+    solution_projection=projections,
+    sample_validator=x -> is_feasible(x, constraint_vec),
+    kwargs...,
+  )
 end
 
 """
@@ -82,17 +101,153 @@ Solve the Polynomial Unconstrained Binary Optimization problem
 
 See also [`maximize`](@ref).
 """
-function minimize(::DMRGBackend, p::AbstractPolynomial{T}; cutoff=1e-8, kwargs...) where T
+function minimize(::DMRGBackend, p::AbstractPolynomial{T}; cutoff=1e-8, constraints=AbstractConstraint[], kwargs...) where T
+  constraint_vec = normalize_constraints(constraints)
   H   = tensorize(p)
   cte = constant(p)
   vs = variables(p)
-  return minimize_mpo(H, cte, a -> p(vs => a); cutoff, kwargs...)
+
+  if isempty(constraint_vec)
+    return minimize_mpo(H, cte, a -> p(vs => a); cutoff, kwargs...)
+  end
+
+  H_eff, initial_state, projections = constrained_projection_problem(T, H, constraint_vec; cutoff)
+
+  return minimize_mpo(
+    H_eff,
+    cte,
+    a -> p(vs => a);
+    cutoff,
+    initial_state,
+    solution_projection=projections,
+    sample_validator=x -> is_feasible(x, constraint_vec),
+    kwargs...,
+  )
 end
 
 
 #----------------------------------------------------------#
 # The actual computations                                  #
 #----------------------------------------------------------#
+
+function normalize_constraints(constraints)
+  constraints isa AbstractVector ||
+    throw(ArgumentError("`constraints` must be an AbstractVector of AbstractConstraint values"))
+
+  constraint_vec = AbstractConstraint[]
+  for (i, constraint) in pairs(constraints)
+    constraint isa AbstractConstraint ||
+      throw(ArgumentError("constraints[$i] must be an AbstractConstraint, got $(typeof(constraint))"))
+    push!(constraint_vec, constraint)
+  end
+
+  return constraint_vec
+end
+
+function tensor_order_constraints(constraints::AbstractVector{<:AbstractConstraint}, permutation)
+  is_identity_permutation(permutation) && return constraints
+
+  original_to_tensor = invperm(permutation)
+  return AbstractConstraint[
+    tensor_order_constraint(constraint, original_to_tensor)
+    for constraint in constraints
+  ]
+end
+
+function tensor_site(site, original_to_tensor)
+  checkbounds(original_to_tensor, site)
+  return original_to_tensor[site]
+end
+
+function tensor_order_constraint(constraint::SumConstraint, original_to_tensor)
+  sites = constraint_sites(constraint)
+  return SumConstraint(
+    [tensor_site(site, original_to_tensor) for site in sites],
+    [constraint.weights[site] for site in sites],
+    constraint.relation,
+    constraint.rhs,
+  )
+end
+
+function tensor_order_constraint(constraint::NotEqualsConstraint, original_to_tensor)
+  sites = constraint_sites(constraint)
+  return NotEqualsConstraint(
+    [tensor_site(site, original_to_tensor) for site in sites],
+    [constraint.values[site] for site in sites],
+  )
+end
+
+function tensor_order_constraint(constraint::ExactlyOneConstraint, original_to_tensor)
+  return ExactlyOneConstraint(
+    [tensor_site(site, original_to_tensor) for site in constraint.sites],
+    constraint.value,
+  )
+end
+
+function tensor_order_constraint(constraint::RelationConstraint, original_to_tensor)
+  return RelationConstraint(
+    tensor_site(constraint.left_site, original_to_tensor),
+    constraint.relation,
+    tensor_site(constraint.right_site, original_to_tensor),
+  )
+end
+
+function constrained_projection_problem(::Type{T}, H, constraints; cutoff) where {T}
+  sites = ITensorMPS.siteinds(first, H; plev=0)
+  projections = projection_mpos(T, constraints, sites)
+  initial_state = constrained_initial_state(sites, projections; cutoff)
+  H_eff = is_zero_mpo(H) ? H : project_hamiltonian(H, projections; cutoff)
+
+  @debug(
+    "Constraint projection MPO construction finished",
+    projection_max_bond=map(ITensorMPS.maxlinkdim, projections),
+    projected_hamiltonian_max_bond=ITensorMPS.maxlinkdim(H_eff),
+    projected_initial_max_bond=ITensorMPS.maxlinkdim(initial_state),
+  )
+
+  return H_eff, initial_state, projections
+end
+
+is_zero_mpo(H::MPO) = all(iszero, H)
+
+function constrained_initial_state(sites, projections; cutoff)
+  psi = ITensorMPS.MPS(sites, fill("full", length(sites)))
+  return project_feasible_state(
+    psi,
+    projections;
+    cutoff,
+    error_type=ArgumentError,
+    message="constraints define an empty feasible subspace; no binary vector satisfies all constraints",
+  )
+end
+
+function project_feasible_state(psi::MPS, projections; cutoff, error_type, message)
+  projected = project_state(psi, projections; cutoff)
+
+  if iszero(norm(projected))
+    throw(error_type(message))
+  end
+
+  return normalize(projected)
+end
+
+function sampled_objective(dist, obj; sample_validator, feasible_sample_retries)
+  feasible_sample_retries >= 1 ||
+    throw(ArgumentError("`feasible_sample_retries` must be >= 1, got $feasible_sample_retries"))
+
+  if isnothing(sample_validator)
+    return obj(sample(dist))
+  end
+
+  local last_sample
+  for _ in 1:feasible_sample_retries
+    x = sample(dist)
+    sample_validator(x) && return obj(x)
+    last_sample = x
+  end
+
+  throw(ErrorException("failed to sample a feasible constrained solution after $(feasible_sample_retries) attempts; last sample was $(last_sample)"))
+end
 
 
 # Strict upper triangular part of an array
@@ -225,8 +380,14 @@ function minimize_mpo( H :: MPO
                      , on_iteration :: Union{Nothing, Function} = nothing
                      , callback_every   :: Int = 1
                      , permutation :: Vector{Int} = Int[]
+                     , initial_state :: Union{Nothing, MPS} = nothing
+                     , solution_projection = nothing
+                     , sample_validator = nothing
+                     , feasible_sample_retries :: Integer = 100
                      ) where {T}
   callback_every >= 1 || throw(ArgumentError("`callback_every` must be >= 1, got $callback_every"))
+  feasible_sample_retries >= 1 ||
+    throw(ArgumentError("`feasible_sample_retries` must be >= 1, got $feasible_sample_retries"))
   initial_time      = time()
   energies_log      = T[]
   bond_dims_log     = Int[]
@@ -235,13 +396,15 @@ function minimize_mpo( H :: MPO
   # Quantization
   sites = ITensorMPS.siteinds(first, H; plev=0)
   solution_permutation = isempty(permutation) ? collect(1:length(sites)) : permutation
+  solution_projections = isnothing(solution_projection) ? nothing : map(device, projection_sequence(solution_projection))
 
-  if length(sites) == 1
+  if length(sites) == 1 && isnothing(initial_state) && isnothing(solution_projections)
     return single_variable_minimize(T, sites, obj, initial_time; device, verbosity, on_iteration, callback_every)
   end
 
   H     = device(H)
-  psi   = ITensorMPS.random_mps(T, sites; linkdims=inidim) |> device
+  psi   = isnothing(initial_state) ? ITensorMPS.random_mps(T, sites; linkdims=inidim) : initial_state
+  psi   = device(psi)
 
   @debug("MPO construction finished",
     time=(time() - initial_time),
@@ -267,6 +430,17 @@ function minimize_mpo( H :: MPO
                       , eigsolve_maxiter
                       , eigsolve_verbosity = 0
                  )
+
+    if !isnothing(solution_projections)
+      psi = project_feasible_state(
+        psi,
+        solution_projections;
+        cutoff,
+        error_type=ErrorException,
+        message="constrained DMRG produced a state with zero feasible amplitude; constraints may be infeasible or the projection cutoff may be too large",
+      )
+      energy = real(expectation(H, psi))
+    end
 
     # Get metadata #
     if i % check_variance_every_iteration == 0
@@ -314,8 +488,12 @@ function minimize_mpo( H :: MPO
   # The calculated energy has approximation errors compared to the true solution.
   # It makes more sense to sample a solution and calculate the true objective function applied to it.
   dist = Solution{T}(psi, energies_log, bond_dims_log, elapsed_times_log, solution_permutation)
-  x    = sample(dist)
-  optimal = obj(x)
+  optimal = sampled_objective(
+    dist,
+    obj;
+    sample_validator,
+    feasible_sample_retries,
+  )
   elapsed_time = time() - initial_time
 
   iterlog_footer(verbosity, optimal, elapsed_time)

--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -1,5 +1,5 @@
 import ITensors: inner
-import ITensorMPS: MPS, MPO, dmrg, OpSum, @OpName_str, @SiteType_str, @StateName_str, dim
+import ITensorMPS: MPS, MPO, OpSum, @OpName_str, @SiteType_str, @StateName_str, dim
 
 import ITensors, ITensorMPS
 
@@ -88,8 +88,8 @@ See also [`maximize`](@ref).
 function minimize(::DMRGBackend, p::AbstractPolynomial{T}; cutoff=1e-8, kwargs...) where T
   H      = tensorize(p)
   cte    = constant_term(p)
-  vs     = variables(p)
-  obj(x) = p(vs => x)
+  vs     = effective_variables(p)
+  obj(x) = real(p(vs => x))
 
   return minimize_mpo(H, cte, obj ; cutoff, kwargs...)
 end
@@ -121,15 +121,19 @@ function constant_term(p::AbstractPolynomial{T}) where T
   return isnothing(idx) ? zero(T) : coefficient(ts[idx])
 end
 
-function constrained_initial_state(sites, projections; cutoff)
-  psi = ITensorMPS.MPS(sites, fill("full", length(sites)))
-  return project_feasible_state(
-    psi,
-    projections;
-    cutoff,
-    error_type=ArgumentError,
-    message="constraints define an empty feasible subspace; no binary vector satisfies all constraints",
-  )
+function constrained_initial_state(T, sites, projections; cutoff, inidim)
+  if isempty(projections)
+    return ITensorMPS.random_mps(T, sites; linkdims=inidim)
+  else
+    psi = ITensorMPS.random_mps(T, sites; linkdims=inidim)
+    return project_feasible_state(
+      psi,
+      projections;
+      cutoff,
+      error_type=ArgumentError,
+      message="constraints define an empty feasible subspace; no binary vector satisfies all constraints",
+    )
+  end
 end
 
 function project_feasible_state(psi::MPS, projections; cutoff, error_type, message)
@@ -203,53 +207,6 @@ function tensorize(p::AbstractPolynomial{T}; cutoff = zero(T)) where T
   return isempty(os) ? MPO(T,sites) : MPO(T, os, sites)
 end
 
-
-function single_variable_minimize(
-  ::Type{T},
-  sites,
-  obj,
-  initial_time;
-  device,
-  verbosity,
-  on_iteration,
-  callback_every,
-  constraints,
-) where {T}
-  feasible_samples = [
-    x for x in ([0], [1])
-    if is_feasible(x, constraints)
-  ]
-
-  if isempty(feasible_samples)
-    throw(ArgumentError("constraints define an empty feasible subspace; no binary vector satisfies all constraints"))
-  end
-
-  feasible_values = [obj(x) for x in feasible_samples]
-
-  energy, state = if length(feasible_samples) == 2 && feasible_values[1] == feasible_values[2]
-    (T(feasible_values[1]), ["full"])
-  else
-    idx = argmin(feasible_values)
-    (T(feasible_values[idx]), string.(feasible_samples[idx]))
-  end
-
-  psi = ITensorMPS.MPS(sites, state) |> device
-  elapsed_time = time() - initial_time
-  bond_dim = ITensorMPS.maxlinkdim(psi)
-
-  iterlog_header(verbosity)
-  iterlog_iteration(verbosity, 1, energy, bond_dim, 0.0, elapsed_time)
-
-  dist = Solution{T}(psi, T[energy], Int[bond_dim], Float64[elapsed_time])
-  if !isnothing(on_iteration) && 1 % callback_every == 0
-    on_iteration(psi; iteration=1, objective=energy, bond_dim, elapsed_time)
-  end
-
-  iterlog_footer(verbosity, energy, elapsed_time)
-
-  return energy, dist
-end
-
 function minimize_mpo( H :: MPO
                      , c :: T
                      , obj
@@ -289,42 +246,22 @@ function minimize_mpo( H :: MPO
   solution_permutation = isempty(permutation) ? collect(1:length(sites)) : permutation
 
   # Constraints
-  constraints  = constraint_reindex(collect(AbstractConstraint, constraints), permutation)
-  projections  = projection_mpos(T, constraints, sites)
-  H_eff = is_zero_mpo(H; cutoff) ? H : project_hamiltonian(H, projections; cutoff)
+  constraints = constraint_reindex(collect(AbstractConstraint, constraints), permutation)
+  projections = map(device, projection_mpos(T, constraints, sites))
+
+  # Hamiltonian construction
+  H = device(H)
+  H = is_zero_mpo(H; cutoff) ? H : project_hamiltonian(H, projections; cutoff)
 
   # Initial state
-  psi = if isempty(constraints)
-          ITensorMPS.random_mps(T, sites; linkdims=inidim)
-        else
-          constrained_initial_state(sites, projections; cutoff)
-        end
-
-  if length(sites) == 1
-    return single_variable_minimize(
-      T,
-      sites,
-      obj,
-      initial_time;
-      device,
-      verbosity,
-      on_iteration,
-      callback_every,
-      constraints
-    )
-  end
+  psi = constrained_initial_state(T, sites, projections; cutoff, inidim) |> device
 
   @debug(
     "Constraint projection MPO construction finished",
     projection_max_bond = map(ITensorMPS.maxlinkdim, projections),
-    projected_hamiltonian_max_bond = ITensorMPS.maxlinkdim(H_eff),
+    projected_hamiltonian_max_bond = ITensorMPS.maxlinkdim(H),
     projected_initial_max_bond = ITensorMPS.maxlinkdim(psi),
   )
-
-  # GPU acceleration
-  H     = device(H_eff)
-  psi   = device(psi)
-  projections = map(device, projections)
 
   @debug("MPO construction finished",
     time=(time() - initial_time),
@@ -336,7 +273,7 @@ function minimize_mpo( H :: MPO
   local energy, psi
 
   for i in Iterators.countfrom(1)
-    energy, psi = dmrg(H, device(psi)
+    energy, psi = groundstate(H, device(psi)
                       ; nsweeps     = 1
                       , ishermitian = true
                       , outputlevel = 0
@@ -399,7 +336,10 @@ function minimize_mpo( H :: MPO
       @debug "Stopping: maximum time reached" iteration=i limit=time_limit time=elapsed_time
       break
     elseif var < vtol
-      @debug "Stopping: variance below tolerance" variance=var tolerance=vtol
+      @debug "Stopping: variance below tolerance" iteration=i variance=var tolerance=vtol
+      break
+    elseif length(H) == 1
+      @debug "Stopping: solver is exact for n=1" iteration=i
       break
     end
   end
@@ -413,4 +353,25 @@ function minimize_mpo( H :: MPO
   iterlog_footer(verbosity, optimal, elapsed_time)
 
   return optimal, dist
+end
+
+function groundstate(H::MPO, psi0::MPS; kwargs...)
+  if length(psi0) != 1
+    return ITensorMPS.dmrg(H, psi0; kwargs...)
+  else
+    sites = ITensorMPS.siteinds(psi0)
+    b0 = ITensorMPS.MPS(sites, ["0"])
+    b1 = ITensorMPS.MPS(sites, ["1"])
+
+    e0 = real(expectation(H, b0))
+    e1 = real(expectation(H, b1))
+
+    return if e0 ≈ e1
+      e0, ITensorMPS.MPS(sites, ["full"])
+    elseif e0 < e1
+      e0, b0
+    else
+      e1, b1
+    end
+  end
 end

--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -274,7 +274,8 @@ function minimize_mpo( H :: MPO
 
   for i in Iterators.countfrom(1)
     energy, psi = groundstate(H, device(psi)
-                      ; nsweeps     = 1
+                      ; projections
+                      , nsweeps     = 1
                       , ishermitian = true
                       , outputlevel = 0
                       , cutoff
@@ -287,6 +288,12 @@ function minimize_mpo( H :: MPO
                       , eigsolve_verbosity = 0
                  )
 
+    # Re-project each iteration so the sampled bitstring is guaranteed feasible.
+    # In exact arithmetic the sweep keeps a feasible start feasible (the local
+    # eigensolver only ever applies P'HP to a feasible state), but the injected
+    # `noise` term and SVD truncation can leak amplitude into the infeasible
+    # subspace. That subspace is the kernel of the projections, where P'HP has
+    # zero energy, so the leaked amplitude is never penalized back out on its own.
     if !isempty(projections)
       psi = project_feasible_state(
         psi,
@@ -355,23 +362,39 @@ function minimize_mpo( H :: MPO
   return optimal, dist
 end
 
-function groundstate(H::MPO, psi0::MPS; kwargs...)
+function groundstate(H::MPO, psi0::MPS; projections=(), cutoff=1e-8, kwargs...)
   if length(psi0) != 1
-    return ITensorMPS.dmrg(H, psi0; kwargs...)
-  else
-    sites = ITensorMPS.siteinds(psi0)
-    b0 = ITensorMPS.MPS(sites, ["0"])
-    b1 = ITensorMPS.MPS(sites, ["1"])
-
-    e0 = real(expectation(H, b0))
-    e1 = real(expectation(H, b1))
-
-    return if e0 ≈ e1
-      e0, ITensorMPS.MPS(sites, ["full"])
-    elseif e0 < e1
-      e0, b0
-    else
-      e1, b1
-    end
+    return ITensorMPS.dmrg(H, psi0; cutoff, kwargs...)
   end
+
+  # ITensorMPS.dmrg does not support single-site systems, so solve the n=1
+  # problem by directly comparing basis states. When constrained, we must
+  # restrict the search to feasible basis states: the projected Hamiltonian
+  # P'HP assigns zero energy to the infeasible subspace (the kernel of the
+  # projections), so picking the global lowest-energy basis state would select
+  # an infeasible one whenever the feasible objective is positive.
+  sites = ITensorMPS.siteinds(psi0)
+  candidates = [ITensorMPS.MPS(sites, [s]) for s in ("0", "1")]
+
+  if !isempty(projections)
+    candidates = filter(
+      b -> !iszero(norm(project_state(b, projections; cutoff))),
+      candidates,
+    )
+    isempty(candidates) && throw(ArgumentError(
+      "constraints define an empty feasible subspace; no binary vector satisfies all constraints",
+    ))
+  end
+
+  energies = map(b -> real(expectation(H, b)), candidates)
+  emin = minimum(energies)
+
+  # Degenerate feasible states: return their uniform superposition so sampling
+  # is unbiased (preserves the previous unconstrained n=1 behavior).
+  if length(candidates) == 2 && all(≈(emin), energies)
+    return emin, ITensorMPS.MPS(sites, ["full"])
+  end
+
+  i = argmin(energies)
+  return energies[i], candidates[i]
 end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -221,11 +221,11 @@ function constraint_sites end
 
 # TODO: Why do we always have to sort it?
 function constraint_sites(constraint::SumConstraint)
-  return sort!(collect(keys(constraint.weights)))
+  return keys(constraint.weights)
 end
 
 function constraint_sites(constraint::NotEqualsConstraint)
-  return sort!(collect(keys(constraint.values)))
+  return keys(constraint.values)
 end
 
 function constraint_sites(constraint::ExactlyOneConstraint)
@@ -234,59 +234,6 @@ end
 
 function constraint_sites(constraint::RelationConstraint)
   return [constraint.left_site, constraint.right_site]
-end
-
-
-function tensor_site(site, original_to_tensor)
-  checkbounds(original_to_tensor, site)
-  return original_to_tensor[site]
-end
-
-#----------------------------------------------
-# Reindexing and site permutation
-#----------------------------------------------
-
-function constraint_reindex(constraint::SumConstraint, original_to_tensor)
-  sites = constraint_sites(constraint)
-  return SumConstraint(
-    [original_to_tensor[site] for site in sites],
-    [constraint.weights[site] for site in sites],
-    constraint.relation,
-    constraint.rhs,
-  )
-end
-
-function constraint_reindex(constraint::NotEqualsConstraint, original_to_tensor)
-  sites = constraint_sites(constraint)
-  return NotEqualsConstraint(
-    [original_to_tensor[site] for site in sites],
-    [constraint.values[site] for site in sites],
-  )
-end
-
-function constraint_reindex(constraint::ExactlyOneConstraint, original_to_tensor)
-  return ExactlyOneConstraint(
-    [original_to_tensor[site] for site in constraint.sites],
-    constraint.value,
-  )
-end
-
-function constraint_reindex(constraint::RelationConstraint, original_to_tensor)
-  return RelationConstraint(
-    original_to_tensor[constraint.left_site],
-    constraint.relation,
-    original_to_tensor[constraint.right_site],
-  )
-end
-
-function constraint_reindex(constraints::AbstractVector{<:AbstractConstraint}, permutation)
-  is_identity_permutation(permutation) && return constraints
-
-  original_to_tensor = invperm(permutation)
-  return AbstractConstraint[
-    constraint_reindex(constraint, original_to_tensor)
-    for constraint in constraints
-  ]
 end
 
 #----------------------------------------------------------#

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -12,7 +12,7 @@ Any concrete subtype is expected to implement
 - [`is_feasible`](@ref).
 - [`constraint_sites`](@ref).
 
-Native constraint types are experimental. They currently provide TenSolver's
+Constraint types are experimental. They currently provide TenSolver's
 Julia lowering target for projection-MPO constrained solves; future JuMP/MOI
 integration may change which constraint abstraction is considered stable public
 API.
@@ -236,6 +236,58 @@ function constraint_sites(constraint::RelationConstraint)
   return [constraint.left_site, constraint.right_site]
 end
 
+
+function tensor_site(site, original_to_tensor)
+  checkbounds(original_to_tensor, site)
+  return original_to_tensor[site]
+end
+
+#----------------------------------------------
+# Reindexing and site permutation
+#----------------------------------------------
+
+function constraint_reindex(constraint::SumConstraint, original_to_tensor)
+  sites = constraint_sites(constraint)
+  return SumConstraint(
+    [original_to_tensor[site] for site in sites],
+    [constraint.weights[site] for site in sites],
+    constraint.relation,
+    constraint.rhs,
+  )
+end
+
+function constraint_reindex(constraint::NotEqualsConstraint, original_to_tensor)
+  sites = constraint_sites(constraint)
+  return NotEqualsConstraint(
+    [original_to_tensor[site] for site in sites],
+    [constraint.values[site] for site in sites],
+  )
+end
+
+function constraint_reindex(constraint::ExactlyOneConstraint, original_to_tensor)
+  return ExactlyOneConstraint(
+    [original_to_tensor[site] for site in constraint.sites],
+    constraint.value,
+  )
+end
+
+function constraint_reindex(constraint::RelationConstraint, original_to_tensor)
+  return RelationConstraint(
+    original_to_tensor[constraint.left_site],
+    constraint.relation,
+    original_to_tensor[constraint.right_site],
+  )
+end
+
+function constraint_reindex(constraints::AbstractVector{<:AbstractConstraint}, permutation)
+  is_identity_permutation(permutation) && return constraints
+
+  original_to_tensor = invperm(permutation)
+  return AbstractConstraint[
+    constraint_reindex(constraint, original_to_tensor)
+    for constraint in constraints
+  ]
+end
 
 #----------------------------------------------------------#
 # Constraint Validation

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -12,6 +12,11 @@ Any concrete subtype is expected to implement
 - [`is_feasible`](@ref).
 - [`constraint_sites`](@ref).
 
+Native constraint types are experimental. They currently provide TenSolver's
+Julia lowering target for projection-MPO constrained solves; future JuMP/MOI
+integration may change which constraint abstraction is considered stable public
+API.
+
 See also [`SumConstraint`](@ref), [`NotEqualsConstraint`](@ref),
 [`ExactlyOneConstraint`](@ref), and [`RelationConstraint`](@ref).
 """

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -88,6 +88,17 @@ end
 DFA(; states, alphabet, initial, accepting, transitions) =
   DFA(states, alphabet, initial, accepting, transitions)
 
+function permute_dfa!(dfa::DFA, permutation::AbstractVector{<:Integer})
+  length(permutation) == length(dfa.transitions) ||
+    throw(DimensionMismatch("DFA permutation length must match the number of transition tables"))
+
+  reordered = dfa.transitions[permutation]
+  for i in eachindex(reordered)
+    dfa.transitions[i] = reordered[i]
+  end
+
+  return dfa
+end
 
 function tensor_from_nonzeros(::Type{T}, inds, nonzeros) where {T}
   ind_tuple = Tuple(inds)
@@ -237,17 +248,16 @@ For a constraint with rhs `k`, its maximum bond dimension is `k+2`.
 function projection_mpo end
 
 
-function projection_mpo(
-  ::Type{T},
-  constraint::AbstractConstraint,
-  sites,
-  permutation = 1:length(sites),
-) where {T}
-  return dfa_to_mpo(T, constraint_to_dfa(constraint, invperm(permutation)), sites)
+function projection_mpo(::Type{T}
+                       , constraint::AbstractConstraint
+                       , sites
+                       ; permutation = 1:length(sites)) where {T}
+  dfa = permute_dfa!(constraint_to_dfa(constraint, length(sites)), permutation)
+  return dfa_to_mpo(T, dfa, sites)
 end
 
-projection_mpo(constraint::AbstractConstraint, args...) =
-  projection_mpo(Float64, constraint, args...)
+projection_mpo(constraint::AbstractConstraint, sites; kws...) =
+  projection_mpo(Float64, constraint, sites; kws...)
 
 """
     projection_mpos([T], constraints, sites)
@@ -259,12 +269,12 @@ This is a convenience wrapper around [`projection_mpo`](@ref).
 `T` controls the numeric
 element type of the assembled MPO tensors.
 """
-function projection_mpos(::Type{T}, constraints::AbstractVector{<:AbstractConstraint}, args...) where {T}
-  return [projection_mpo(T, constraint, args...) for constraint in constraints]
+function projection_mpos(::Type{T}, constraints::AbstractVector{<:AbstractConstraint}, sites; kws...) where {T}
+  return [projection_mpo(T, constraint, sites; kws...) for constraint in constraints]
 end
 
-projection_mpos(constraints::AbstractVector{<:AbstractConstraint}, args...) =
-  projection_mpos(Float64, constraints, args...)
+projection_mpos(constraints::AbstractVector{<:AbstractConstraint}, sites; kws...) =
+  projection_mpos(Float64, constraints, sites; kws...)
 
 """
     project_hamiltonian(H, projections; cutoff=1e-8, kwargs...)
@@ -468,20 +478,13 @@ end
 ##############################################
 
 """
-    constraint_to_dfa(constraint, indices)
+    constraint_to_dfa(constraint, n)
 
-Build a DFA for `constraint` over `sites`.
-
-The argument `indices` is a vector describing the mapping
-variable indices, as specified in the constraints, to tensor site indices.
+Build a [`DFA`](@ref) recognizing `constraint` with transitions for `n` steps.
 """
 function constraint_to_dfa end
 
-function constraint_to_dfa(constraint::AbstractConstraint, nsites::Integer)
-  return constraint_to_dfa(constraint, collect(1:nsites))
-end
-
-function constraint_to_dfa(constraint::SumConstraint{S}, indices::Vector{Int}) where {S}
+function constraint_to_dfa(constraint::SumConstraint{S}, nsites::Integer) where {S}
   (; weights, rhs, relation) = constraint
 
   beyond    = rhs + one(S)
@@ -491,13 +494,12 @@ function constraint_to_dfa(constraint::SumConstraint{S}, indices::Vector{Int}) w
   accepting = Set(q for q in states if relation_holds(q, relation, rhs))
 
   id_dict = Dict((q, a) => q for q in states for a in alphabet)
-  transitions = fill(id_dict, length(indices))
+  transitions = fill(id_dict, nsites)
 
   for site in constraint_sites(constraint)
-    tensor_site = indices[site]
     weight = weights[site]
 
-    transitions[tensor_site] = Dict(
+    transitions[site] = Dict(
       (q, a) => min(q + weight * a, beyond)
       for q in states, a in alphabet
     )
@@ -506,20 +508,19 @@ function constraint_to_dfa(constraint::SumConstraint{S}, indices::Vector{Int}) w
   return DFA(states, alphabet, initial, accepting, transitions)
 end
 
-function constraint_to_dfa(constraint::NotEqualsConstraint{S}, indices::Vector{Int}) where {S}
+function constraint_to_dfa(constraint::NotEqualsConstraint{S}, nsites::Int) where {S}
   states    = S[0, 1]
   alphabet  = S[0, 1]
   initial   = one(S)
   accepting = Set([zero(S)])
 
   id_dict = Dict((q, a) => q for q in states for a in alphabet)
-  transitions = fill(id_dict, length(indices))
+  transitions = fill(id_dict, nsites)
 
   for site in constraint_sites(constraint)
-    tensor_site = indices[site]
     target = constraint.values[site]
 
-    transitions[tensor_site] = Dict(
+    transitions[site] = Dict(
       (q, a) => S(a) == target ? q : zero(S)
       for q in states, a in alphabet
     )
@@ -528,7 +529,7 @@ function constraint_to_dfa(constraint::NotEqualsConstraint{S}, indices::Vector{I
   return DFA(states, alphabet, initial, accepting, transitions)
 end
 
-function constraint_to_dfa(constraint::ExactlyOneConstraint{S}, indices::Vector{Int}) where {S}
+function constraint_to_dfa(constraint::ExactlyOneConstraint{S}, nsites::Integer) where {S}
   target = constraint.value
   not_seen  = zero(S)
   seen_once = one(S)
@@ -539,11 +540,10 @@ function constraint_to_dfa(constraint::ExactlyOneConstraint{S}, indices::Vector{
   accepting = Set([seen_once])
 
   id_dict = Dict((q, a) => q for q in states for a in alphabet)
-  transitions = fill(id_dict, length(indices))
+  transitions = fill(id_dict, nsites)
 
   for site in constraint_sites(constraint)
-    tensor_site = indices[site]
-    transitions[tensor_site] = Dict(
+    transitions[site] = Dict(
       (q, a) => (a == target ? seen_once : q)
       for q in states, a in alphabet
       if !(q == seen_once && a == target)
@@ -553,9 +553,10 @@ function constraint_to_dfa(constraint::ExactlyOneConstraint{S}, indices::Vector{
   return DFA(states, alphabet, initial, accepting, transitions)
 end
 
-function constraint_to_dfa(constraint::RelationConstraint, indices::Vector{Int})
-  left  = indices[constraint.left_site]
-  right = indices[constraint.right_site]
+function constraint_to_dfa(constraint::RelationConstraint, nsites::Integer)
+  left  = constraint.left_site
+  right = constraint.right_site
+
   first_site    = min(left, right)
   second_site   = max(left, right)
   left_is_first = left == first_site
@@ -566,7 +567,7 @@ function constraint_to_dfa(constraint::RelationConstraint, indices::Vector{Int})
   accepting = Set(states)
 
   id_dict = Dict((q, a) => q for q in states for a in alphabet)
-  transitions = fill(id_dict, length(indices))
+  transitions = fill(id_dict, nsites)
 
   transitions[first_site] = Dict(
     (q, a) => a for q in states, a in alphabet

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -237,12 +237,17 @@ For a constraint with rhs `k`, its maximum bond dimension is `k+2`.
 function projection_mpo end
 
 
-function projection_mpo(::Type{T}, constraint::AbstractConstraint, sites) where {T}
-  return dfa_to_mpo(T, constraint_to_dfa(constraint, sites), sites)
+function projection_mpo(
+  ::Type{T},
+  constraint::AbstractConstraint,
+  sites,
+  permutation = 1:length(sites),
+) where {T}
+  return dfa_to_mpo(T, constraint_to_dfa(constraint, invperm(permutation)), sites)
 end
 
-projection_mpo(constraint::AbstractConstraint, sites) =
-  projection_mpo(Float64, constraint, sites)
+projection_mpo(constraint::AbstractConstraint, args...) =
+  projection_mpo(Float64, constraint, args...)
 
 """
     projection_mpos([T], constraints, sites)
@@ -254,12 +259,12 @@ This is a convenience wrapper around [`projection_mpo`](@ref).
 `T` controls the numeric
 element type of the assembled MPO tensors.
 """
-function projection_mpos(::Type{T}, constraints::AbstractVector{<:AbstractConstraint}, sites) where {T}
-  return [projection_mpo(T, constraint, sites) for constraint in constraints]
+function projection_mpos(::Type{T}, constraints::AbstractVector{<:AbstractConstraint}, args...) where {T}
+  return [projection_mpo(T, constraint, args...) for constraint in constraints]
 end
 
-projection_mpos(constraints::AbstractVector{<:AbstractConstraint}, sites) =
-  projection_mpos(Float64, constraints, sites)
+projection_mpos(constraints::AbstractVector{<:AbstractConstraint}, args...) =
+  projection_mpos(Float64, constraints, args...)
 
 """
     project_hamiltonian(H, projections; cutoff=1e-8, kwargs...)
@@ -445,16 +450,7 @@ function projection_entries_to_dfa(entries, num_sites::Integer, constrained_site
   return DFA(states, [0, 1], 1, accepting, transitions)
 end
 
-##############################################
-# Constraint to DFA
-##############################################
-
-"""
-    constraint_to_dfa(constraint, sites)
-
-Build a DFA for `constraint` over `sites`.
-"""
-function constraint_to_dfa(constraint::AbstractConstraint, sites)
+function default_constraint_to_dfa(constraint::AbstractConstraint, sites)
   validate_projection_sites(sites)
 
   cs = constraint_sites(constraint)
@@ -467,60 +463,74 @@ function constraint_to_dfa(constraint::AbstractConstraint, sites)
   )
 end
 
-function constraint_to_dfa(constraint::SumConstraint{S}, sites) where {S}
+##############################################
+# Constraint to DFA
+##############################################
+
+"""
+    constraint_to_dfa(constraint, indices)
+
+Build a DFA for `constraint` over `sites`.
+
+The argument `indices` is a vector describing the mapping
+variable indices, as specified in the constraints, to tensor site indices.
+"""
+function constraint_to_dfa end
+
+function constraint_to_dfa(constraint::AbstractConstraint, nsites::Integer)
+  return constraint_to_dfa(constraint, collect(1:nsites))
+end
+
+function constraint_to_dfa(constraint::SumConstraint{S}, indices::Vector{Int}) where {S}
   (; weights, rhs, relation) = constraint
 
   beyond    = rhs + one(S)
   states    = zero(S):beyond
-  alphabet  = [0, 1]
+  alphabet  = S[0, 1]
+  initial   = zero(S)
   accepting = Set(q for q in states if relation_holds(q, relation, rhs))
 
-  transitions = [
-    let weight = get(weights, i, zero(S))
-      Dict(
-        (q, a) => min(q + weight * S(a), beyond)
-        for q in states, a in alphabet
-      )
-    end
-    for i in eachindex(sites)
-  ]
+  id_dict = Dict((q, a) => q for q in states for a in alphabet)
+  transitions = fill(id_dict, length(indices))
 
-  return DFA(states, alphabet, zero(S), accepting, transitions)
-end
+  for site in constraint_sites(constraint)
+    tensor_site = indices[site]
+    weight = weights[site]
 
-function constraint_to_dfa(constraint::NotEqualsConstraint{S}, sites) where {S}
-  validate_projection_sites(sites)
-
-  cs = constraint_sites(constraint)
-  validate_constraint_site_bounds(cs, sites)
-
-  states    = S.([0, 1])
-  alphabet  = [0, 1]
-  initial   = 1
-  accepting = Set(0)
-
-  transitions = [
-    let target = get(constraint.values, i, nothing)
-      Dict{Tuple{Int,Int},Int}(
-        (q, a) => isnothing(target) || S(a) == target ? q : 0
-        for q in states, a in alphabet
-      )
-    end
-    for i in eachindex(sites)
-  ]
+    transitions[tensor_site] = Dict(
+      (q, a) => min(q + weight * a, beyond)
+      for q in states, a in alphabet
+    )
+  end
 
   return DFA(states, alphabet, initial, accepting, transitions)
 end
 
-function constraint_to_dfa(constraint::ExactlyOneConstraint{S}, sites) where {S}
-  validate_projection_sites(sites)
+function constraint_to_dfa(constraint::NotEqualsConstraint{S}, indices::Vector{Int}) where {S}
+  states    = S[0, 1]
+  alphabet  = S[0, 1]
+  initial   = one(S)
+  accepting = Set([zero(S)])
 
-  cs = constraint_sites(constraint)
-  validate_constraint_site_bounds(cs, sites)
+  id_dict = Dict((q, a) => q for q in states for a in alphabet)
+  transitions = fill(id_dict, length(indices))
 
+  for site in constraint_sites(constraint)
+    tensor_site = indices[site]
+    target = constraint.values[site]
+
+    transitions[tensor_site] = Dict(
+      (q, a) => S(a) == target ? q : zero(S)
+      for q in states, a in alphabet
+    )
+  end
+
+  return DFA(states, alphabet, initial, accepting, transitions)
+end
+
+function constraint_to_dfa(constraint::ExactlyOneConstraint{S}, indices::Vector{Int}) where {S}
   target = constraint.value
-  constrained_sites = Set(cs)
-  not_seen = zero(S)
+  not_seen  = zero(S)
   seen_once = one(S)
 
   states    = S[not_seen, seen_once]
@@ -528,54 +538,46 @@ function constraint_to_dfa(constraint::ExactlyOneConstraint{S}, sites) where {S}
   initial   = not_seen
   accepting = Set([seen_once])
 
-  transitions = [
-    if i in constrained_sites
-      Dict{Tuple{Int,Int},Int}(
-        (q, a) => (a == target ? seen_once : q)
-        for q in states, a in alphabet
-        if !(q == seen_once && a == target)
-      )
-    else
-      Dict{Tuple{Int,Int},Int}((q, a) => q for q in states, a in alphabet)
-    end
-    for i in eachindex(sites)
-  ]
+  id_dict = Dict((q, a) => q for q in states for a in alphabet)
+  transitions = fill(id_dict, length(indices))
+
+  for site in constraint_sites(constraint)
+    tensor_site = indices[site]
+    transitions[tensor_site] = Dict(
+      (q, a) => (a == target ? seen_once : q)
+      for q in states, a in alphabet
+      if !(q == seen_once && a == target)
+    )
+  end
 
   return DFA(states, alphabet, initial, accepting, transitions)
 end
 
-function constraint_to_dfa(constraint::RelationConstraint, sites)
-  validate_projection_sites(sites)
-
-  cs = constraint_sites(constraint)
-  validate_constraint_site_bounds(cs, sites)
-
-  (; left_site, relation, right_site) = constraint
-  first_site    = min(left_site, right_site)
-  second_site   = max(left_site, right_site)
-  left_is_first = left_site == first_site
+function constraint_to_dfa(constraint::RelationConstraint, indices::Vector{Int})
+  left  = indices[constraint.left_site]
+  right = indices[constraint.right_site]
+  first_site    = min(left, right)
+  second_site   = max(left, right)
+  left_is_first = left == first_site
 
   states    = [0, 1]
   alphabet  = [0, 1]
   initial   = 1
   accepting = Set(states)
 
-  transitions = [
-    if i == first_site
-      Dict{Tuple{Int,Int},Int}((q, a) => a for q in states, a in alphabet)
-    elseif i == second_site
-      Dict{Tuple{Int,Int},Int}(
-        (q, a) => q
-        for q in states, a in alphabet
-        if left_is_first ?
-          relation_holds(q, relation, a) :
-          relation_holds(a, relation, q)
-      )
-    else
-      Dict{Tuple{Int,Int},Int}((q, a) => q for q in states, a in alphabet)
-    end
-    for i in eachindex(sites)
-  ]
+  id_dict = Dict((q, a) => q for q in states for a in alphabet)
+  transitions = fill(id_dict, length(indices))
+
+  transitions[first_site] = Dict(
+    (q, a) => a for q in states, a in alphabet
+  )
+
+  transitions[second_site] = Dict(
+    (q, a) => q
+    for q in states, a in alphabet
+    if left_is_first ? relation_holds(q, constraint.relation, a) :
+                       relation_holds(a, constraint.relation, q)
+  )
 
   return DFA(states, alphabet, initial, accepting, transitions)
 end

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -170,8 +170,8 @@ for maximization.
     max  b'Qb + l'b + c
     s.t. b_i in {0, 1}
 
-The same `constraints` keyword accepted by [`minimize`](@ref) can be used to
-solve constrained maximization problems.
+The same `constraints` and `feasible_sample_retries` keywords accepted by
+[`minimize`](@ref) can be used to solve constrained maximization problems.
 
 See also [`minimize`](@ref).
 """

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -85,13 +85,6 @@ Keyword arguments:
 - `preprocess :: Bool` - Defaults to `false`. If `true`, permute QUBO variables before constructing the MPS Hamiltonian
   so coupled variables are closer in the one-dimensional tensor order. Samples are returned in the
   caller's original variable order. This is an experimental feature and may be subject to changes.
-- `constraints :: AbstractVector{<:AbstractConstraint}` - Experimental native Julia hard constraints.
-  Defaults to `AbstractConstraint[]`. In constrained DMRG solves, TenSolver lowers each constraint to
-  a projection MPO, solves the projected Hamiltonian, and returns a feasible sampled bitstring.
-  QUBO constraints are expressed in the caller's original variable order, even when `preprocess=true`.
-  Polynomial constraints are expressed in the effective variable order used by the polynomial Hamiltonian.
-- `feasible_sample_retries :: Int` - Maximum attempts to draw a feasible bitstring from a constrained
-  final state before throwing a diagnostic error. Defaults to `100`.
 - `on_iteration :: Function` - Called after each recorded iteration as
   `f(psi::MPS; iteration, objective, bond_dim, elapsed_time)`.
   `objective` is the expected objective function ⟨ψ|H|ψ⟩ at this iteration.
@@ -170,8 +163,7 @@ for maximization.
     max  b'Qb + l'b + c
     s.t. b_i in {0, 1}
 
-The same `constraints` and `feasible_sample_retries` keywords accepted by
-[`minimize`](@ref) can be used to solve constrained maximization problems.
+All keywords accepted by [`minimize`](@ref) can also be used for maximization problems.
 
 See also [`minimize`](@ref).
 """

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -85,6 +85,13 @@ Keyword arguments:
 - `preprocess :: Bool` - Defaults to `false`. If `true`, permute QUBO variables before constructing the MPS Hamiltonian
   so coupled variables are closer in the one-dimensional tensor order. Samples are returned in the
   caller's original variable order. This is an experimental feature and may be subject to changes.
+- `constraints :: AbstractVector{<:AbstractConstraint}` - Experimental native Julia hard constraints.
+  Defaults to `AbstractConstraint[]`. In constrained DMRG solves, TenSolver lowers each constraint to
+  a projection MPO, solves the projected Hamiltonian, and returns a feasible sampled bitstring.
+  QUBO constraints are expressed in the caller's original variable order, even when `preprocess=true`.
+  Polynomial constraints are expressed in the effective variable order used by the polynomial Hamiltonian.
+- `feasible_sample_retries :: Int` - Maximum attempts to draw a feasible bitstring from a constrained
+  final state before throwing a diagnostic error. Defaults to `100`.
 - `on_iteration :: Function` - Called after each recorded iteration as
   `f(psi::MPS; iteration, objective, bond_dim, elapsed_time)`.
   `objective` is the expected objective function ⟨ψ|H|ψ⟩ at this iteration.
@@ -162,6 +169,9 @@ for maximization.
 
     max  b'Qb + l'b + c
     s.t. b_i in {0, 1}
+
+The same `constraints` keyword accepted by [`minimize`](@ref) can be used to
+solve constrained maximization problems.
 
 See also [`minimize`](@ref).
 """

--- a/test/constrained_solve.jl
+++ b/test/constrained_solve.jl
@@ -1,24 +1,4 @@
 import DynamicPolynomials
-const ConstrainedSolveDP = DynamicPolynomials
-
-function constrained_brute_force(obj, n, constraints)
-  best = Inf
-  best_x = nothing
-
-  for bits in Iterators.product(fill(0:1, n)...)
-    x = collect(bits)
-    is_feasible(x, constraints) || continue
-
-    value = obj(x)
-    if value < best
-      best = value
-      best_x = x
-    end
-  end
-
-  isnothing(best_x) && throw(ArgumentError("no feasible bitstring"))
-  return best, best_x
-end
 
 function assert_constrained_solution(E, psi, obj, constraints, expected_energy, expected_sample)
   x = TenSolver.sample(psi)
@@ -53,7 +33,7 @@ end
     Q = zeros(3, 3)
     l = [-3.0, -2.0, -1.0]
     obj(x) = dot(x, Q, x) + dot(l, x)
-    expected_energy, expected_sample = constrained_brute_force(obj, 3, all_constraint_types)
+    expected_energy, expected_sample = brute_force(obj, 3, all_constraint_types)
 
     E, psi = minimize(Q, l; qubo_kwargs...)
 
@@ -69,7 +49,7 @@ end
     ]
     l = [-3.0, -2.0, -1.0]
     obj(x) = dot(x, Q, x) + dot(l, x)
-    expected_energy, expected_sample = constrained_brute_force(obj, 3, all_constraint_types)
+    expected_energy, expected_sample = brute_force(obj, 3, all_constraint_types)
 
     E, psi = minimize(Q, l; preprocess=true, qubo_kwargs...)
 
@@ -101,10 +81,10 @@ end
   end
 
   @testset "Polynomial minimize supports constraints" begin
-    ConstrainedSolveDP.@polyvar y[1:3]
+    DynamicPolynomials.@polyvar y[1:3]
     p = -3.0y[1] - 2.0y[2] - 1.0y[3]
     obj(x) = p(y => x)
-    expected_energy, expected_sample = constrained_brute_force(obj, 3, all_constraint_types)
+    expected_energy, expected_sample = brute_force(obj, 3, all_constraint_types)
 
     E, psi = minimize(
       p;
@@ -136,7 +116,7 @@ end
 
     assert_constrained_solution(E, psi, obj, force_zero, 0.0, [0])
 
-    ConstrainedSolveDP.@polyvar z
+    DynamicPolynomials.@polyvar z
     p = -2.0z + 0.0
     force_one = AbstractConstraint[ExactlyOneConstraint([1], 1)]
     poly_obj(x) = p([z] => x)

--- a/test/constrained_solve.jl
+++ b/test/constrained_solve.jl
@@ -118,6 +118,41 @@ end
     assert_constrained_solution(E, psi, obj, all_constraint_types, expected_energy, expected_sample)
   end
 
+  @testset "Single-variable constrained problems use the scalar fast path" begin
+    Q = zeros(1, 1)
+    l = [-1.0]
+    force_zero = AbstractConstraint[SumConstraint([1], [1], 0; relation=:(==))]
+    obj(x) = dot(x, Q, x) + dot(l, x)
+
+    E, psi = minimize(
+      Q,
+      l;
+      constraints=force_zero,
+      iterations=3,
+      verbosity=0,
+      cutoff=1e-12,
+      noise=[0.0],
+    )
+
+    assert_constrained_solution(E, psi, obj, force_zero, 0.0, [0])
+
+    ConstrainedSolveDP.@polyvar z
+    p = -2.0z + 0.0
+    force_one = AbstractConstraint[ExactlyOneConstraint([1], 1)]
+    poly_obj(x) = p([z] => x)
+
+    E_poly, psi_poly = minimize(
+      p;
+      constraints=force_one,
+      iterations=3,
+      verbosity=0,
+      cutoff=1e-12,
+      noise=[0.0],
+    )
+
+    assert_constrained_solution(E_poly, psi_poly, poly_obj, force_one, -2.0, [1])
+  end
+
   @testset "Callbacks and stats remain available" begin
     Q = zeros(2, 2)
     l = [-1.0, -2.0]

--- a/test/constrained_solve.jl
+++ b/test/constrained_solve.jl
@@ -1,0 +1,179 @@
+import DynamicPolynomials
+const ConstrainedSolveDP = DynamicPolynomials
+
+function constrained_brute_force(obj, n, constraints)
+  best = Inf
+  best_x = nothing
+
+  for bits in Iterators.product(fill(0:1, n)...)
+    x = collect(bits)
+    is_feasible(x, constraints) || continue
+
+    value = obj(x)
+    if value < best
+      best = value
+      best_x = x
+    end
+  end
+
+  isnothing(best_x) && throw(ArgumentError("no feasible bitstring"))
+  return best, best_x
+end
+
+function assert_constrained_solution(E, psi, obj, constraints, expected_energy, expected_sample)
+  x = TenSolver.sample(psi)
+
+  @test is_feasible(x, constraints)
+  @test x == expected_sample
+  @test obj(x) ≈ E
+  @test E ≈ expected_energy
+
+  for sampled in TenSolver.sample(psi, 5)
+    @test is_feasible(sampled, constraints)
+  end
+end
+
+@testset "Constrained solving" begin
+  all_constraint_types = AbstractConstraint[
+    SumConstraint([1, 2, 3], [1, 1, 1], 2; relation=:(<=)),
+    NotEqualsConstraint([1, 2], [1, 1]),
+    ExactlyOneConstraint([2, 3], 1),
+    RelationConstraint(1, :(>=), 3),
+  ]
+
+  qubo_kwargs = (
+    constraints=all_constraint_types,
+    iterations=3,
+    verbosity=0,
+    cutoff=1e-12,
+    noise=[0.0],
+  )
+
+  @testset "QUBO minimize supports all v1 constraints" begin
+    Q = zeros(3, 3)
+    l = [-3.0, -2.0, -1.0]
+    obj(x) = dot(x, Q, x) + dot(l, x)
+    expected_energy, expected_sample = constrained_brute_force(obj, 3, all_constraint_types)
+
+    E, psi = minimize(Q, l; qubo_kwargs...)
+
+    @test expected_sample == [1, 0, 1]
+    assert_constrained_solution(E, psi, obj, all_constraint_types, expected_energy, expected_sample)
+  end
+
+  @testset "QUBO preprocessing keeps constraints in original variable order" begin
+    Q = [
+      0.0 0.0 0.1
+      0.0 0.0 0.0
+      0.1 0.0 0.0
+    ]
+    l = [-3.0, -2.0, -1.0]
+    obj(x) = dot(x, Q, x) + dot(l, x)
+    expected_energy, expected_sample = constrained_brute_force(obj, 3, all_constraint_types)
+
+    E, psi = minimize(Q, l; preprocess=true, qubo_kwargs...)
+
+    @test !TenSolver.is_identity_permutation(TenSolver.qmatrix_permutation(Q; cutoff=1e-12))
+    assert_constrained_solution(E, psi, obj, all_constraint_types, expected_energy, expected_sample)
+  end
+
+  @testset "Maximize forwards constraints" begin
+    Q = zeros(2, 2)
+    l = [1.0, 2.0]
+    constraints = AbstractConstraint[ExactlyOneConstraint([1, 2], 1)]
+    obj(x) = dot(x, Q, x) + dot(l, x)
+
+    E, psi = maximize(
+      Q,
+      l;
+      constraints,
+      iterations=3,
+      verbosity=0,
+      cutoff=1e-12,
+      noise=[0.0],
+    )
+    x = TenSolver.sample(psi)
+
+    @test is_feasible(x, constraints)
+    @test x == [0, 1]
+    @test obj(x) ≈ E
+    @test E ≈ 2.0
+  end
+
+  @testset "Polynomial minimize supports constraints" begin
+    ConstrainedSolveDP.@polyvar y[1:3]
+    p = -3.0y[1] - 2.0y[2] - 1.0y[3]
+    obj(x) = p(y => x)
+    expected_energy, expected_sample = constrained_brute_force(obj, 3, all_constraint_types)
+
+    E, psi = minimize(
+      p;
+      constraints=all_constraint_types,
+      iterations=3,
+      verbosity=0,
+      cutoff=1e-12,
+      noise=[0.0],
+    )
+
+    assert_constrained_solution(E, psi, obj, all_constraint_types, expected_energy, expected_sample)
+  end
+
+  @testset "Callbacks and stats remain available" begin
+    Q = zeros(2, 2)
+    l = [-1.0, -2.0]
+    constraints = AbstractConstraint[NotEqualsConstraint([1, 2], [1, 1])]
+    calls = Int[]
+    objectives = Float64[]
+
+    E, psi = minimize(
+      Q,
+      l;
+      constraints,
+      iterations=2,
+      verbosity=0,
+      cutoff=1e-12,
+      noise=[0.0],
+      on_iteration=(mps; iteration, objective, kw...) -> begin
+        push!(calls, iteration)
+        push!(objectives, objective)
+        @test is_feasible(TenSolver.sample(TenSolver.Solution(deepcopy(mps), Float64[], Int[], Float64[])), constraints)
+      end,
+    )
+
+    @test calls == [1, 2]
+    @test length(objectives) == 2
+    @test length(psi.energies) == 2
+    @test length(psi.bond_dims) == 2
+    @test length(psi.elapsed_times) == 2
+    @test is_feasible(TenSolver.sample(psi), constraints)
+    @test E ≈ -2.0
+  end
+
+  @testset "Zero objective keeps feasible constrained samples" begin
+    constraints = AbstractConstraint[ExactlyOneConstraint([1, 2], 1)]
+    E, psi = minimize(
+      zeros(2, 2);
+      constraints,
+      iterations=2,
+      verbosity=0,
+      cutoff=1e-12,
+    )
+
+    @test E ≈ 0.0
+    for sampled in TenSolver.sample(psi, 5)
+      @test is_feasible(sampled, constraints)
+    end
+  end
+
+  @testset "Infeasible constraints fail clearly" begin
+    impossible = AbstractConstraint[SumConstraint([1, 2], [1, 1], 3; relation=:(==))]
+    err = try
+      minimize(zeros(2, 2); constraints=impossible, verbosity=0)
+    catch err
+      err
+    end
+
+    @test err isa ArgumentError
+    @test occursin("empty feasible subspace", sprint(showerror, err))
+  end
+end

--- a/test/constrained_solve.jl
+++ b/test/constrained_solve.jl
@@ -131,6 +131,42 @@ end
     )
 
     assert_constrained_solution(E_poly, psi_poly, poly_obj, force_one, -2.0, [1])
+
+    # Regression: with a positive feasible objective, the projected Hamiltonian
+    # P'HP assigns zero energy to the (infeasible) rejected basis state, so the
+    # scalar path must still select the feasible one rather than the global
+    # minimum. Previously this threw a misleading "constraints may be infeasible"
+    # error even though the pinned assignment is feasible.
+    Qpos = fill(3.0, 1, 1)
+    force_one_qubo = AbstractConstraint[SumConstraint([1], [1], 1; relation=:(==))]
+    qubo_pos_obj(x) = dot(x, Qpos, x)
+
+    E_qpos, psi_qpos = minimize(
+      Qpos;
+      constraints=force_one_qubo,
+      iterations=3,
+      verbosity=0,
+      cutoff=1e-12,
+      noise=[0.0],
+    )
+
+    assert_constrained_solution(E_qpos, psi_qpos, qubo_pos_obj, force_one_qubo, 3.0, [1])
+
+    DynamicPolynomials.@polyvar w
+    p_pos = 2.0w + 0.0
+    force_one_poly = AbstractConstraint[ExactlyOneConstraint([1], 1)]
+    poly_pos_obj(x) = p_pos([w] => x)
+
+    E_ppos, psi_ppos = minimize(
+      p_pos;
+      constraints=force_one_poly,
+      iterations=3,
+      verbosity=0,
+      cutoff=1e-12,
+      noise=[0.0],
+    )
+
+    assert_constrained_solution(E_ppos, psi_ppos, poly_pos_obj, force_one_poly, 2.0, [1])
   end
 
   @testset "Callbacks and stats remain available" begin

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -3,7 +3,7 @@
     sum = SumConstraint([1, 3], [2, 1], Symbol("<="), 2)
     @test sum isa SumConstraint
     @test sum isa AbstractConstraint
-    @test TenSolver.constraint_sites(sum) == [1, 3]
+    @test Set(TenSolver.constraint_sites(sum)) == Set([1, 3])
     @test sum.weights == Dict(1 => 2, 3 => 1)
     @test sum.relation == Symbol("<=")
     @test sum.rhs == 2
@@ -16,12 +16,12 @@
     not_equals = NotEqualsConstraint([1, 2], [1, 0])
     @test not_equals isa NotEqualsConstraint{Int}
     @test not_equals isa AbstractConstraint
-    @test TenSolver.constraint_sites(not_equals) == [1, 2]
+    @test Set(TenSolver.constraint_sites(not_equals)) == Set([1, 2])
     @test not_equals.values == Dict(1 => 1, 2 => 0)
 
     float_not_equals = NotEqualsConstraint([1, 2], [1.0, 0.0])
     @test float_not_equals isa NotEqualsConstraint{Float64}
-    @test TenSolver.constraint_sites(float_not_equals) == [1, 2]
+    @test Set(TenSolver.constraint_sites(float_not_equals)) == Set([1, 2])
     @test float_not_equals.values == Dict(1 => 1.0, 2 => 0.0)
 
     exactly_one = ExactlyOneConstraint(2:4, 1)

--- a/test/jump.jl
+++ b/test/jump.jl
@@ -16,7 +16,7 @@ import JuMP
   e = JuMP.objective_value(m)
 
   # ~:~ Exact solution ~:~ #
-  e0, x0 = brute_force(obj, Float64, dim)
+  e0, x0 = brute_force(obj, dim)
   # Same minimum value
   @test e ≈ e0
   # Same solution

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -94,7 +94,7 @@ end
     sites = ITensors.siteinds("Qudit", 4; dim=2)
 
     for constraint in TEST_CONSTRAINTS
-      dfa = TenSolver.constraint_to_dfa(constraint, sites)
+      dfa = TenSolver.constraint_to_dfa(constraint, length(sites))
 
       for bits in all_bitstrings(sites)
         expected = is_feasible(collect(bits), constraint)
@@ -248,7 +248,7 @@ end
     ]
 
     for (constraint, sites) in cases
-      dfa = @inferred TenSolver.constraint_to_dfa(constraint, sites)
+      dfa = @inferred TenSolver.constraint_to_dfa(constraint, length(sites))
       @test length(dfa.states) == 2
 
       for bits in all_bitstrings(sites)
@@ -271,7 +271,7 @@ end
     ]
 
     for constraint in relation_cases
-      dfa = TenSolver.constraint_to_dfa(constraint, sites)
+      dfa = TenSolver.constraint_to_dfa(constraint, length(sites))
       @test length(dfa.states) <= 2
 
       for bits in all_bitstrings(sites)
@@ -287,7 +287,7 @@ end
     sites = ITensors.siteinds("Qudit", 4; dim=2)
 
     exact_one = ExactlyOneConstraint([1, 3], 1)
-    dfa = TenSolver.constraint_to_dfa(exact_one, sites)
+    dfa = TenSolver.constraint_to_dfa(exact_one, length(sites))
     H = assert_projection_matches_feasibility(exact_one, sites)
 
     @test length(dfa.states) == 2
@@ -305,7 +305,7 @@ end
     ]
 
     for constraint in constraints
-      dfa = TenSolver.constraint_to_dfa(constraint, sites)
+      dfa = TenSolver.constraint_to_dfa(constraint, length(sites))
       H = TenSolver.projection_mpo(constraint, sites)
 
       for bits in all_bitstrings(sites)

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -187,6 +187,44 @@ end
     end
   end
 
+  @testset "Projection MPO permutation" begin
+    sites = ITensors.siteinds("Qudit", 4; dim=2)
+    perm = [3, 1, 4, 2]
+
+    constraint = RelationConstraint(1, :(<=), 4)
+    H = TenSolver.projection_mpo(constraint, sites; permutation=perm)
+
+    for bits in all_bitstrings(sites)
+      # tensor-order bits -> original-order bits
+      original_bits = collect(bits)[invperm(perm)]
+      expected = Float64(is_feasible(original_bits, constraint))
+      @test mpo_diagonal(H, sites, bits) ≈ expected
+    end
+  end
+
+  @testset "Projection MPO permutation with multiple constraints" begin
+    sites = ITensors.siteinds("Qudit", 5; dim=2)
+    perm = [4, 1, 5, 2, 3]
+
+    constraints = AbstractConstraint[
+      SumConstraint([1, 5], [1, 1], 1; relation=:(==)),
+      NotEqualsConstraint([2, 4], [1, 0]),
+      RelationConstraint(3, :(>=), 1),
+    ]
+
+    Hs = TenSolver.projection_mpos(constraints, sites; permutation=perm)
+
+    @test length(Hs) == length(constraints)
+
+    for (constraint, H) in zip(constraints, Hs)
+      for bits in all_bitstrings(sites)
+        original_bits = collect(bits)[invperm(perm)]
+        expected = Float64(is_feasible(original_bits, constraint))
+        @test mpo_diagonal(H, sites, bits) ≈ expected
+      end
+    end
+  end
+
   @testset "Infeasible projections remain zero" begin
     H = TenSolver.tensorize([1.0 0.5; 0.5 2.0])
     sites = ITensorMPS.siteinds(first, H; plev=0)

--- a/test/pubo.jl
+++ b/test/pubo.jl
@@ -26,7 +26,7 @@ function test_correctness(dim, obj, args...)
     end
 
     # ~:~ Exact solution ~:~ #
-    e0, x0 = brute_force(Float64, obj, dim)
+    e0, x0 = brute_force(obj, dim)
     # Same minimum value
     @test e ≈ e0
     # Solution is sampleable

--- a/test/pubo.jl
+++ b/test/pubo.jl
@@ -26,7 +26,7 @@ function test_correctness(dim, obj, args...)
     end
 
     # ~:~ Exact solution ~:~ #
-    e0, x0 = brute_force(obj, Float64, dim)
+    e0, x0 = brute_force(Float64, obj, dim)
     # Same minimum value
     @test e ≈ e0
     # Solution is sampleable

--- a/test/qubo.jl
+++ b/test/qubo.jl
@@ -273,7 +273,7 @@
 
     # ~:~ Exact solution ~:~ #
 
-    e0, x0 = brute_force(x -> dot(x, Q, x), Float64, dim)
+    e0, x0 = brute_force( Float64, x -> dot(x, Q, x), dim)
     # Same minimum value
     @test e ≈ e0
     # Same solution
@@ -303,7 +303,7 @@
     end
 
     # ~:~ Exact solution ~:~ #
-    e0, x0 = brute_force(obj, Float64, dim)
+    e0, x0 = brute_force(Float64, obj, dim)
     # Same minimum value
     @test e ≈ e0
     # Solution is sampleable

--- a/test/qubo.jl
+++ b/test/qubo.jl
@@ -273,7 +273,7 @@
 
     # ~:~ Exact solution ~:~ #
 
-    e0, x0 = brute_force( Float64, x -> dot(x, Q, x), dim)
+    e0, x0 = brute_force(x -> dot(x, Q, x), dim)
     # Same minimum value
     @test e ≈ e0
     # Same solution
@@ -303,7 +303,7 @@
     end
 
     # ~:~ Exact solution ~:~ #
-    e0, x0 = brute_force(Float64, obj, dim)
+    e0, x0 = brute_force(obj, dim)
     # Same minimum value
     @test e ≈ e0
     # Solution is sampleable

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ include(filepath("ising_conversion.jl"))
 # Binary constraint API
 include(filepath("constraints.jl"))
 include(filepath("projection_mpo.jl"))
+include(filepath("constrained_solve.jl"))
 
 # Traditional interface
 include(filepath("qubo.jl"))

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -9,24 +9,27 @@
 A QUBO solver using a brute force approach instead of Tensor networks.
 Despite being painfully slow, this is useful as a sanity check.
 """
-function brute_force(f::Function, T, n::Int64)
-  min_now  = +Inf
+function brute_force(T::Type, obj, n, constraints = AbstractConstraint[])
+  best = +Inf
   solution = Vector{T}[]
 
-  for i in 0:(2^n-1)
-    # The Boolean vector corresponding to the natural i
-    bs = [convert(T, parse(Bool, d)) for d in last(bitstring(i), n)]
-    z  = f(bs)
+  for bits in Iterators.product(fill(0:1, n)...)
+    x = collect(bits)
 
-    if z < min_now
-      solution = bs
-      min_now  = z
+    if is_feasible(x, constraints)
+      value = obj(x)
+      if value < best
+        best = value
+        solution = x
+      end
     end
-
   end
 
-  return min_now, solution
+  isempty(solution) && throw(ArgumentError("no feasible bitstring"))
+  return best, solution
 end
+
+brute_force(obj, n::Integer, constraints) = brute_force(Float64, obj, n, constraints)
 
 function mpo_matrix_element(H, sites, bra_bits, ket_bits)
   bra = ITensorMPS.MPS(sites, string.(bra_bits))

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -4,14 +4,14 @@
 =#
 
 """
-    brute_force(f, n)
+    brute_force(f, n[, constraints])
 
 A QUBO solver using a brute force approach instead of Tensor networks.
 Despite being painfully slow, this is useful as a sanity check.
 """
-function brute_force(T::Type, obj, n, constraints = AbstractConstraint[])
+function brute_force(obj, n, constraints = AbstractConstraint[])
   best = +Inf
-  solution = Vector{T}[]
+  solution = Vector{Float64}[]
 
   for bits in Iterators.product(fill(0:1, n)...)
     x = collect(bits)
@@ -28,8 +28,6 @@ function brute_force(T::Type, obj, n, constraints = AbstractConstraint[])
   isempty(solution) && throw(ArgumentError("no feasible bitstring"))
   return best, solution
 end
-
-brute_force(obj, n::Integer, constraints) = brute_force(Float64, obj, n, constraints)
 
 function mpo_matrix_element(H, sites, bra_bits, ket_bits)
   bra = ITensorMPS.MPS(sites, string.(bra_bits))


### PR DESCRIPTION
## Summary

- Add `constraints=` support to DMRG-backed QUBO and polynomial `minimize`, with `maximize` forwarding constraints through the existing sign-flip path.
- Lower constraints through the existing DFA/projection-MPO path, solve the projected Hamiltonian, project constrained DMRG states before callbacks/final sampling, and retry final sampling with clear diagnostics.
- Keep QUBO constraints in original variable coordinates when `preprocess=true`, add a zero-Hamiltonian projection guard, and mark the native constraint API experimental in docs.
- Add focused constrained-solver tests covering all v1 constraint types, preprocessing, constrained `maximize`, polynomial `minimize`, callbacks/stats, zero objectives, and infeasible diagnostics.

Closes #62.

## Tests

- `julia --project=test -e 'using Pkg; Pkg.instantiate()'`
- `julia --project=test -e 'push!(LOAD_PATH, pwd()); include(joinpath(pwd(), "test", "runtests.jl"))'`

## Branch Hygiene

- Base branch: `main`
- Source branch: `pr-7-constrained-minimize-maximize`
- Branch point: `origin/main` at `9f487c765b0b2a079a01e8f42ae7bbe7da7b451a`
- Stacked status: unstacked; #37 and #61 are already merged into `main`
- Prerequisites: none beyond current `main`
