### PR TITLE
Drop VRP mindim workaround; LAPACKException no longer reproduces

### DIFF
--- a/test/cases/vrp.jl
+++ b/test/cases/vrp.jl
@@ -21,7 +21,7 @@ end
 @testset "Vehicle Routing Problem (VRP)" begin
   Q, beta = vrp_6nodes()
 
-  E, psi = minimize(Q, beta; cutoff=1e-10, mindim = 2)
+  E, psi = minimize(Q, beta; cutoff=1e-10)
   x = TenSolver.sample(psi)
 
   # Known Solution


### PR DESCRIPTION
## Summary

Removes the `mindim = 2` workaround from `test/cases/vrp.jl`, added in `89d528c` (2024-12) after `LAPACKException` crashes in the DMRG eigensolver on the VRP QUBO family (#1, originally reported on ITensors 0.6).

## Evidence the crash is gone

Re-tested the in-tree VRP instance with the default `mindim = 1` on the current dependency stack — **ITensors v0.9.30, ITensorMPS v0.4.1, Julia 1.10.11**:

- 20/20 random seeds: no `LAPACKException`, no other exception.
- Every seed reached the known optimum `E = 5.0` with a valid solution vector.
- The modified test file passes as-is (`Vehicle Routing Problem (VRP) | 2 pass`).

Since the report, the DMRG path also gained `ishermitian = true` and exposed `eigsolve_krylovdim`/`eigsolve_maxiter`/`eigsolve_tol` knobs plus a default noise schedule, and the ITensors stack moved 0.6 → 0.9 — any of which plausibly resolved the underlying KrylovKit/LAPACK instability.

## Notes

- The original report also mentioned crashes on the Anvil HPC environment; that environment was not re-tested here. If it ever reproduces there again, #1 can be reopened with a fresh stack trace against ITensors 0.9 and escalated upstream.
- `test/cases/pharma.jl` still passes `mindim = 2`; that case belongs to the #19 local-minima investigation and is intentionally untouched here.

Closes #1
