### PR TITLE
Report infeasibility as status instead of exception

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -21,7 +21,6 @@ TenSolver.normalize_backend
 
 ```@docs
 TenSolver.Solution
-TenSolver.is_infeasible
 ```
 
 ## Sampling Functions

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -21,6 +21,7 @@ TenSolver.normalize_backend
 
 ```@docs
 TenSolver.Solution
+TenSolver.is_infeasible
 ```
 
 ## Sampling Functions

--- a/src/TenSolver.jl
+++ b/src/TenSolver.jl
@@ -8,7 +8,7 @@ using LinearAlgebra
 const __VERSION__ = pkgversion(@__MODULE__)
 
 include("solution.jl")
-export sample
+export sample, is_infeasible
 
 include("preprocess.jl")
 
@@ -99,8 +99,11 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
   _, psi = results.value
 
   # ~ Samples and Output ~ #
-  samples = Vector{QUBOTools.Sample{T,Int}}(undef, final_num_reads)
-  for i in 1:final_num_reads
+  # Infeasible models have no samples; they are reported through the
+  # termination status alone, like other MOI solvers.
+  reads = is_infeasible(psi) ? 0 : final_num_reads
+  samples = Vector{QUBOTools.Sample{T,Int}}(undef, reads)
+  for i in 1:reads
     x = sample(psi)
     E = QUBOTools.value(x, l, Q, a, b)
 
@@ -173,7 +176,9 @@ end
 
 function tensolver_status(solution::Solution; iterations::Integer, time_limit::Real)
   elapsed_time = isempty(solution.elapsed_times) ? 0.0 : last(solution.elapsed_times)
-  if length(solution.energies) >= iterations
+  if is_infeasible(solution)
+    return MOI.INFEASIBLE, "infeasible"
+  elseif length(solution.energies) >= iterations
     return MOI.ITERATION_LIMIT, "iteration_limit"
   elseif isfinite(time_limit) && elapsed_time > time_limit
     return MOI.TIME_LIMIT, "time_limit"

--- a/src/TenSolver.jl
+++ b/src/TenSolver.jl
@@ -7,9 +7,6 @@ using LinearAlgebra
 
 const __VERSION__ = pkgversion(@__MODULE__)
 
-include("solution.jl")
-export sample, is_infeasible
-
 include("preprocess.jl")
 
 include("ising.jl")
@@ -21,6 +18,9 @@ export SumConstraint, NotEqualsConstraint, ExactlyOneConstraint, RelationConstra
 export is_feasible
 
 include("projection_mpo.jl")
+
+include("solution.jl")
+export sample
 
 include("solver.jl")
 export minimize, maximize
@@ -101,7 +101,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
   # ~ Samples and Output ~ #
   # Infeasible models have no samples; they are reported through the
   # termination status alone, like other MOI solvers.
-  reads = is_infeasible(psi) ? 0 : final_num_reads
+  reads = is_feasible(psi) ? final_num_reads : 0
   samples = Vector{QUBOTools.Sample{T,Int}}(undef, reads)
   for i in 1:reads
     x = sample(psi)
@@ -176,7 +176,7 @@ end
 
 function tensolver_status(solution::Solution; iterations::Integer, time_limit::Real)
   elapsed_time = isempty(solution.elapsed_times) ? 0.0 : last(solution.elapsed_times)
-  if is_infeasible(solution)
+  if !is_feasible(solution)
     return MOI.INFEASIBLE, "infeasible"
   elseif length(solution.energies) >= iterations
     return MOI.ITERATION_LIMIT, "iteration_limit"

--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -42,8 +42,8 @@ Backend-specific keyword arguments:
   Defaults to `AbstractConstraint[]`. In constrained DMRG solves, TenSolver lowers each constraint to
   a projection MPO, solves the projected Hamiltonian, and returns a feasible sampled bitstring.
   For polynomial objectives, constraints are expressed in the same order as their `effective_variables`.
-  When the constraints admit no binary vector at all, the solve does not error: it logs a warning and
-  returns `+Inf` together with an infeasible [`Solution`](@ref) (see [`is_infeasible`](@ref)).
+  If the constraints admit no solution at all, the solve does not error: it logs a warning and
+  returns `+Inf` together with an infeasible [`Solution`](@ref) (see [`is_feasible`](@ref)).
 - `maxdim` - The maximum allowed bond dimension.
   Integer or array of integer specifying the bond dimension per iteration.
   You can use this keyword to control the solver's accuracy vs resources trade-off.
@@ -101,7 +101,8 @@ end
 
 # Structural check for freshly tensorized zero objectives; this is not a
 # semantic zero-operator test after arbitrary MPO algebra.
-is_zero_mpo(H::MPO; cutoff=0) = norm(H) < cutoff
+is_zero_tensor(H::MPO; cutoff) = norm(H) <= cutoff
+is_zero_tensor(p::MPS; cutoff) = norm(p) <= cutoff
 
 expectation(H::MPO, x::MPS) = real(inner(x', H, x))
 
@@ -130,17 +131,16 @@ end
 
 function project_feasible_state(psi::MPS, projections; cutoff)
   projected = project_state(psi, projections; cutoff)
-  return iszero(norm(projected)) ? nothing : normalize(projected)
+  return is_zero_tensor(projected; cutoff) ? nothing : normalize(projected)
 end
 
 # Infeasibility is a solver outcome, not an argument error: report it as a
 # status like other optimization packages (objective +Inf, empty Solution),
 # so it maps onto MOI.INFEASIBLE at the JuMP layer. See the discussion in #94.
-function infeasible_result(::Type{T}, verbosity, initial_time) where {T}
+function infeasible_result(::Type{T}) where {T}
   @warn "constraints define an empty feasible subspace; no binary vector satisfies all constraints"
   F = float(T)
-  iterlog_footer(verbosity, F(Inf), time() - initial_time)
-  return F(Inf), infeasible_solution(F)
+  return real(T)(+Inf), infeasible_solution(F)
 end
 
 
@@ -246,11 +246,13 @@ function minimize_mpo( H :: MPO
 
   # Hamiltonian construction
   H = device(H)
-  H = is_zero_mpo(H; cutoff) ? H : project_hamiltonian(H, projections; cutoff)
+  H = is_zero_tensor(H; cutoff) ? H : project_hamiltonian(H, projections; cutoff)
 
   # Initial state
   psi = constrained_initial_state(T, sites, projections; cutoff, inidim)
-  isnothing(psi) && return infeasible_result(T, verbosity, initial_time)
+  if isnothing(psi)
+    return infeasible_result(T)
+  end
   psi = device(psi)
 
   @debug(
@@ -262,8 +264,8 @@ function minimize_mpo( H :: MPO
   )
 
   iterlog_header(verbosity)
-  var = Inf
-  local energy, psi
+  var    = T(Inf)
+  energy = T(Inf)
 
   for i in Iterators.countfrom(1)
     energy, psi = groundstate(H, device(psi)
@@ -280,9 +282,6 @@ function minimize_mpo( H :: MPO
                       , eigsolve_maxiter
                       , eigsolve_verbosity = 0
                  )
-
-    # The n=1 fast path signals proven infeasibility by returning no state.
-    isnothing(psi) && return infeasible_result(T, verbosity, initial_time)
 
     # Re-project each iteration so the sampled bitstring is guaranteed feasible.
     # In exact arithmetic the sweep keeps a feasible start feasible (the local
@@ -347,49 +346,53 @@ function minimize_mpo( H :: MPO
     end
   end
 
-  # The calculated energy has approximation errors compared to the true solution.
-  # It makes more sense to sample a solution and calculate the true objective function applied to it.
-  dist = Solution{T}(psi, energies_log, bond_dims_log, elapsed_times_log, permutation)
-  optimal = obj(sample(dist))
+
+  if isinf(energy)
+    optimal, dist = infeasible_result(T)
+  else
+    # The calculated energy has approximation errors compared to the true solution.
+    # It makes more sense to sample a solution and calculate the true objective function applied to it.
+    dist = Solution{T}(psi, energies_log, bond_dims_log, elapsed_times_log, permutation)
+    optimal = obj(sample(dist))
+  end
+
   elapsed_time = time() - initial_time
-
   iterlog_footer(verbosity, optimal, elapsed_time)
-
   return optimal, dist
 end
 
 function groundstate(H::MPO, psi0::MPS; projections=(), cutoff=1e-8, kwargs...)
   if length(psi0) != 1
     return ITensorMPS.dmrg(H, psi0; cutoff, kwargs...)
-  end
-
-  # ITensorMPS.dmrg does not support single-site systems, so solve the n=1
-  # problem by directly comparing basis states. When constrained, we must
-  # restrict the search to feasible basis states: the projected Hamiltonian
-  # P'HP assigns zero energy to the infeasible subspace (the kernel of the
-  # projections), so picking the global lowest-energy basis state would select
-  # an infeasible one whenever the feasible objective is positive.
-  sites = ITensorMPS.siteinds(psi0)
-  candidates = [ITensorMPS.MPS(sites, [s]) for s in ("0", "1")]
-
-  if !isempty(projections)
-    candidates = filter(
-      b -> !iszero(norm(project_state(b, projections; cutoff))),
-      candidates,
-    )
-    # Proven infeasibility; the caller turns this into a status return.
-    isempty(candidates) && return Inf, nothing
-  end
-
-  energies = map(b -> expectation(H, b), candidates)
-  emin = minimum(energies)
-
-  # Degenerate feasible states: return their uniform superposition so sampling
-  # is unbiased (preserves the previous unconstrained n=1 behavior).
-  if length(candidates) == 2 && all(≈(emin), energies)
-    return emin, ITensorMPS.MPS(sites, ["full"])
   else
-    i = argmin(energies)
-    return energies[i], candidates[i]
+    # ITensorMPS.dmrg does not support single-site systems, so solve the n=1
+    # problem by directly comparing basis states. When constrained, we must
+    # restrict the search to feasible basis states: the projected Hamiltonian
+    # P'HP assigns zero energy to the infeasible subspace (the kernel of the
+    # projections), so picking the global lowest-energy basis state would select
+    # an infeasible one whenever the feasible objective is positive.
+    sites = ITensorMPS.siteinds(psi0)
+    candidates = [ITensorMPS.MPS(sites, [s]) for s in ("0", "1")]
+
+    if !isempty(projections)
+      candidates = filter(
+        b -> !is_zero_tensor(project_state(b, projections; cutoff); cutoff),
+        candidates,
+      )
+    end
+
+    if isempty(candidates)
+      return infeasible_result(T)
+    else
+      energies = map(b -> expectation(H, b), candidates)
+      emin, i = findmin(energies)
+      # Degenerate feasible states: return their uniform superposition so sampling
+      # is unbiased (preserves the previous unconstrained n=1 behavior).
+      if length(candidates) == 2 && all(≈(emin), energies)
+        return emin, ITensorMPS.MPS(sites, ["full"])
+      else
+        return energies[i], candidates[i]
+      end
+    end
   end
 end

--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -42,6 +42,8 @@ Backend-specific keyword arguments:
   Defaults to `AbstractConstraint[]`. In constrained DMRG solves, TenSolver lowers each constraint to
   a projection MPO, solves the projected Hamiltonian, and returns a feasible sampled bitstring.
   For polynomial objectives, constraints are expressed in the same order as their `effective_variables`.
+  When the constraints admit no binary vector at all, the solve does not error: it logs a warning and
+  returns `+Inf` together with an infeasible [`Solution`](@ref) (see [`is_infeasible`](@ref)).
 - `maxdim` - The maximum allowed bond dimension.
   Integer or array of integer specifying the bond dimension per iteration.
   You can use this keyword to control the solver's accuracy vs resources trade-off.
@@ -119,29 +121,26 @@ function constant_term(p::AbstractPolynomial{T}) where T
   return isnothing(idx) ? zero(T) : coefficient(ts[idx])
 end
 
+# Returns `nothing` when the projected state has no feasible amplitude,
+# which at the initial state proves the constraints are infeasible.
 function constrained_initial_state(T, sites, projections; cutoff, inidim)
-  if isempty(projections)
-    return ITensorMPS.random_mps(T, sites; linkdims=inidim)
-  else
-    psi = ITensorMPS.random_mps(T, sites; linkdims=inidim)
-    return project_feasible_state(
-      psi,
-      projections;
-      cutoff,
-      error_type=ArgumentError,
-      message="constraints define an empty feasible subspace; no binary vector satisfies all constraints",
-    )
-  end
+  psi = ITensorMPS.random_mps(T, sites; linkdims=inidim)
+  return isempty(projections) ? psi : project_feasible_state(psi, projections; cutoff)
 end
 
-function project_feasible_state(psi::MPS, projections; cutoff, error_type, message)
+function project_feasible_state(psi::MPS, projections; cutoff)
   projected = project_state(psi, projections; cutoff)
+  return iszero(norm(projected)) ? nothing : normalize(projected)
+end
 
-  if iszero(norm(projected))
-    throw(error_type(message))
-  end
-
-  return normalize(projected)
+# Infeasibility is a solver outcome, not an argument error: report it as a
+# status like other optimization packages (objective +Inf, empty Solution),
+# so it maps onto MOI.INFEASIBLE at the JuMP layer. See the discussion in #94.
+function infeasible_result(::Type{T}, verbosity, initial_time) where {T}
+  @warn "constraints define an empty feasible subspace; no binary vector satisfies all constraints"
+  F = float(T)
+  iterlog_footer(verbosity, F(Inf), time() - initial_time)
+  return F(Inf), infeasible_solution(F)
 end
 
 
@@ -250,7 +249,9 @@ function minimize_mpo( H :: MPO
   H = is_zero_mpo(H; cutoff) ? H : project_hamiltonian(H, projections; cutoff)
 
   # Initial state
-  psi = constrained_initial_state(T, sites, projections; cutoff, inidim) |> device
+  psi = constrained_initial_state(T, sites, projections; cutoff, inidim)
+  isnothing(psi) && return infeasible_result(T, verbosity, initial_time)
+  psi = device(psi)
 
   @debug(
     "Constraint projection MPO construction finished",
@@ -280,6 +281,9 @@ function minimize_mpo( H :: MPO
                       , eigsolve_verbosity = 0
                  )
 
+    # The n=1 fast path signals proven infeasibility by returning no state.
+    isnothing(psi) && return infeasible_result(T, verbosity, initial_time)
+
     # Re-project each iteration so the sampled bitstring is guaranteed feasible.
     # In exact arithmetic the sweep keeps a feasible start feasible (the local
     # eigensolver only ever applies P'HP to a feasible state), but the injected
@@ -287,13 +291,13 @@ function minimize_mpo( H :: MPO
     # subspace. That subspace is the kernel of the projections, where P'HP has
     # zero energy, so the leaked amplitude is never penalized back out on its own.
     if !isempty(projections)
-      psi = project_feasible_state(
-        psi,
-        projections;
-        cutoff,
-        error_type=ErrorException,
-        message="constrained DMRG produced a state with zero feasible amplitude; constraints may be infeasible or the projection cutoff may be too large",
+      projected = project_feasible_state(psi, projections; cutoff)
+      # Unlike the initial state, a mid-run collapse does not prove
+      # infeasibility (the start was feasible), so it stays an error.
+      isnothing(projected) && error(
+        "constrained DMRG produced a state with zero feasible amplitude; constraints may be infeasible or the projection cutoff may be too large",
       )
+      psi = projected
       energy = expectation(H, psi)
     end
 
@@ -373,9 +377,8 @@ function groundstate(H::MPO, psi0::MPS; projections=(), cutoff=1e-8, kwargs...)
       b -> !iszero(norm(project_state(b, projections; cutoff))),
       candidates,
     )
-    isempty(candidates) && throw(ArgumentError(
-      "constraints define an empty feasible subspace; no binary vector satisfies all constraints",
-    ))
+    # Proven infeasibility; the caller turns this into a status return.
+    isempty(candidates) && return Inf, nothing
   end
 
   energies = map(b -> expectation(H, b), candidates)

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -21,7 +21,7 @@ The three stats vectors are parallel — `energies[i]`, `bond_dims[i]`, and `ela
 all correspond to iteration `i`.
 
 Provably infeasible models produce a `Solution` with no MPS and empty stats
-vectors; check with [`is_infeasible`](@ref) before sampling.
+vectors; check with [`is_feasible`](@ref) before sampling.
 """
 struct Solution{T <: Real}
     tensor        :: Union{MPS, Nothing}
@@ -51,14 +51,20 @@ infeasible_solution(::Type{T}) where {T <: Real} =
   Solution{T}(nothing, T[], Int[], Float64[], Int[])
 
 """
-    is_infeasible(psi::Solution)
+    is_feasible(psi::Solution)
 
 Whether `psi` came from solving a provably infeasible model, i.e. one whose
 constraints admit no binary vector. Infeasible solutions carry no MPS and
 cannot be sampled; [`minimize`](@ref) reports them with an objective of `+Inf`
 (`-Inf` for [`maximize`](@ref)).
+
+Whether `psi` came from solving a satisfiable model, i.e. one whose
+constraints admit at least one binary vector.
+Feasible solutions carry an MPS and can be sampled;
+
+Check this before calling [`sample`](@ref).
 """
-is_infeasible(psi::Solution) = isnothing(psi.tensor)
+is_feasible(psi::Solution) = !isnothing(psi.tensor)
 
 function original_order(bs, permutation)
   x = similar(bs)
@@ -72,14 +78,16 @@ end
 
 Sample a bitstring from a (quantum) probability distribution.
 
-Throws an `ArgumentError` when `psi` is infeasible (see [`is_infeasible`](@ref)):
-the solve itself reports infeasibility as a status, but there is no solution to
-query.
+Throw a `DomainError` when `psi` is infeasible (see [`is_feasible`](@ref)),
+since there is no solution to query.
 """
 function sample(psi::Solution)
-  is_infeasible(psi) && throw(ArgumentError("the model is infeasible; there is no solution to sample"))
-  bs = ITensorMPS.sample!(psi.tensor) .- 1
-  return original_order(bs, psi.permutation)
+  if is_feasible(psi)
+    bs = ITensorMPS.sample!(psi.tensor) .- 1
+    return original_order(bs, psi.permutation)
+  else
+    throw(DomainError("the model is infeasible; there is no solution to sample"))
+  end
 end
 
 sample(psi::Solution, n :: Integer) = [sample(psi) for _ in 1:n]
@@ -92,12 +100,11 @@ When setting `cutoff`, it will be used as the minimum probability considered pos
 Always `false` for infeasible solutions.
 """
 function Base.in(bs, psi::Solution; cutoff = 1e-8)
-  is_infeasible(psi) && return false
   return prob(psi, bs) > cutoff
 end
 
-function prob(psi::Solution, bs)
-  return abs2(coeff(psi, bs))
+function prob(psi::Solution{T}, bs) where {T}
+  return is_feasible(psi) ? abs2(coeff(psi, bs)) : zero(T)
 end
 
 function coeff(psi::Solution, bs)

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -11,7 +11,7 @@ Use [`sample`](@ref) to draw bitstrings from it.
 
 ## Fields
 
-- `tensor`: the underlying MPS.
+- `tensor`: the underlying MPS, or `nothing` when the model is infeasible.
 - `energies`: expected objective value of the problem recorded at each iteration of the solver.
 - `bond_dims`: maximum MPS bond dimension at each iteration.
 - `elapsed_times`: wall-clock time in seconds from the start of the solve at each iteration.
@@ -19,9 +19,12 @@ Use [`sample`](@ref) to draw bitstrings from it.
 
 The three stats vectors are parallel — `energies[i]`, `bond_dims[i]`, and `elapsed_times[i]`
 all correspond to iteration `i`.
+
+Provably infeasible models produce a `Solution` with no MPS and empty stats
+vectors; check with [`is_infeasible`](@ref) before sampling.
 """
 struct Solution{T <: Real}
-    tensor        :: MPS
+    tensor        :: Union{MPS, Nothing}
     energies      :: Vector{T}
     bond_dims     :: Vector{Int}
     elapsed_times :: Vector{Float64}
@@ -44,6 +47,19 @@ Solution(
   elapsed_times::Vector{Float64},
 ) where {T <: Real} = Solution{T}(tensor, energies, bond_dims, elapsed_times)
 
+infeasible_solution(::Type{T}) where {T <: Real} =
+  Solution{T}(nothing, T[], Int[], Float64[], Int[])
+
+"""
+    is_infeasible(psi::Solution)
+
+Whether `psi` came from solving a provably infeasible model, i.e. one whose
+constraints admit no binary vector. Infeasible solutions carry no MPS and
+cannot be sampled; [`minimize`](@ref) reports them with an objective of `+Inf`
+(`-Inf` for [`maximize`](@ref)).
+"""
+is_infeasible(psi::Solution) = isnothing(psi.tensor)
+
 function original_order(bs, permutation)
   x = similar(bs)
   x[permutation] = bs
@@ -55,8 +71,13 @@ end
     sample(psi)
 
 Sample a bitstring from a (quantum) probability distribution.
+
+Throws an `ArgumentError` when `psi` is infeasible (see [`is_infeasible`](@ref)):
+the solve itself reports infeasibility as a status, but there is no solution to
+query.
 """
 function sample(psi::Solution)
+  is_infeasible(psi) && throw(ArgumentError("the model is infeasible; there is no solution to sample"))
   bs = ITensorMPS.sample!(psi.tensor) .- 1
   return original_order(bs, psi.permutation)
 end
@@ -68,8 +89,10 @@ sample(psi::Solution, n :: Integer) = [sample(psi) for _ in 1:n]
 
 Whether the vector `xs` has a positive probability of being sampleable from `psi`.
 When setting `cutoff`, it will be used as the minimum probability considered positive.
+Always `false` for infeasible solutions.
 """
 function Base.in(bs, psi::Solution; cutoff = 1e-8)
+  is_infeasible(psi) && return false
   return prob(psi, bs) > cutoff
 end
 

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -101,10 +101,10 @@ Keyword arguments:
 
 The returned `Solution` carries per-iteration stats in the fields `energies`, `bond_dims`, and `elapsed_times`.
 
-Provably infeasible constrained models are reported as a status, not an
-exception: `minimize` logs a warning and returns `+Inf` together with an
-infeasible `Solution` (the minimum over an empty feasible set), which cannot be
-sampled. Check with [`is_infeasible`](@ref).
+Provably infeasible constrained models are reported as a status:
+`minimize` logs a warning and returns `+Inf` (the minimum over an empty feasible set)
+together with an infeasible [`Solution`](@ref), which cannot be sampled.
+Check it with [`is_feasible`](@ref).
 
 Running on GPU:
 
@@ -170,7 +170,7 @@ for maximization.
 
 All keywords accepted by [`minimize`](@ref) can also be used for maximization problems.
 Provably infeasible constrained models return `-Inf` (the supremum over an
-empty feasible set) together with an infeasible `Solution`.
+empty feasible set) together with an infeasible [`Solution`](@ref).
 
 See also [`minimize`](@ref).
 """

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -101,6 +101,11 @@ Keyword arguments:
 
 The returned `Solution` carries per-iteration stats in the fields `energies`, `bond_dims`, and `elapsed_times`.
 
+Provably infeasible constrained models are reported as a status, not an
+exception: `minimize` logs a warning and returns `+Inf` together with an
+infeasible `Solution` (the minimum over an empty feasible set), which cannot be
+sampled. Check with [`is_infeasible`](@ref).
+
 Running on GPU:
 
 The optional keyword `device` controls whether the solver should run on CPU or GPU.
@@ -164,6 +169,8 @@ for maximization.
     s.t. b_i in {0, 1}
 
 All keywords accepted by [`minimize`](@ref) can also be used for maximization problems.
+Provably infeasible constrained models return `-Inf` (the supremum over an
+empty feasible set) together with an infeasible `Solution`.
 
 See also [`minimize`](@ref).
 """

--- a/test/constrained_solve.jl
+++ b/test/constrained_solve.jl
@@ -216,15 +216,60 @@ end
     end
   end
 
-  @testset "Infeasible constraints fail clearly" begin
+  @testset "Infeasible constraints report status, not exception" begin
     impossible = AbstractConstraint[SumConstraint([1, 2], [1, 1], 3; relation=:(==))]
-    err = try
-      minimize(zeros(2, 2); constraints=impossible, verbosity=0)
-    catch err
-      err
-    end
 
-    @test err isa ArgumentError
-    @test occursin("empty feasible subspace", sprint(showerror, err))
+    E, psi = @test_logs (:warn, r"empty feasible subspace") minimize(
+      zeros(2, 2);
+      constraints=impossible,
+      verbosity=0,
+    )
+
+    @test E == Inf
+    @test is_infeasible(psi)
+    @test isempty(psi.energies)
+    @test isempty(psi.bond_dims)
+    @test isempty(psi.elapsed_times)
+    # The solve reports; querying a nonexistent solution throws.
+    @test_throws ArgumentError TenSolver.sample(psi)
+    @test [0, 0] ∉ psi
+
+    # The supremum over an empty feasible set is -Inf.
+    Emax, psimax = @test_logs (:warn, r"empty feasible subspace") maximize(
+      zeros(2, 2);
+      constraints=impossible,
+      verbosity=0,
+    )
+
+    @test Emax == -Inf
+    @test is_infeasible(psimax)
+  end
+
+  @testset "Infeasible single-variable solves report status" begin
+    impossible = AbstractConstraint[SumConstraint([1], [1], 2; relation=:(==))]
+
+    E, psi = @test_logs (:warn, r"empty feasible subspace") minimize(
+      ones(1, 1);
+      constraints=impossible,
+      verbosity=0,
+    )
+
+    @test E == Inf
+    @test is_infeasible(psi)
+    @test_throws ArgumentError TenSolver.sample(psi)
+  end
+
+  @testset "Infeasible solutions map to MOI.INFEASIBLE" begin
+    impossible = AbstractConstraint[SumConstraint([1, 2], [1, 1], 3; relation=:(==))]
+    _, psi = @test_logs (:warn, r"empty feasible subspace") minimize(
+      zeros(2, 2);
+      constraints=impossible,
+      verbosity=0,
+    )
+
+    termination_status, status = TenSolver.tensolver_status(psi; iterations=10, time_limit=Inf)
+
+    @test termination_status == TenSolver.MOI.INFEASIBLE
+    @test status == "infeasible"
   end
 end

--- a/test/constrained_solve.jl
+++ b/test/constrained_solve.jl
@@ -226,12 +226,12 @@ end
     )
 
     @test E == Inf
-    @test is_infeasible(psi)
+    @test !is_feasible(psi)
     @test isempty(psi.energies)
     @test isempty(psi.bond_dims)
     @test isempty(psi.elapsed_times)
     # The solve reports; querying a nonexistent solution throws.
-    @test_throws ArgumentError TenSolver.sample(psi)
+    @test_throws DomainError TenSolver.sample(psi)
     @test [0, 0] ∉ psi
 
     # The supremum over an empty feasible set is -Inf.
@@ -242,7 +242,7 @@ end
     )
 
     @test Emax == -Inf
-    @test is_infeasible(psimax)
+    @test !is_feasible(psimax)
   end
 
   @testset "Infeasible single-variable solves report status" begin
@@ -255,8 +255,8 @@ end
     )
 
     @test E == Inf
-    @test is_infeasible(psi)
-    @test_throws ArgumentError TenSolver.sample(psi)
+    @test !is_feasible(psi)
+    @test_throws DomainError TenSolver.sample(psi)
   end
 
   @testset "Infeasible solutions map to MOI.INFEASIBLE" begin


### PR DESCRIPTION
## Summary

Implements the design agreed in the [#94 discussion](https://github.com/SECQUOIA/TenSolver.jl/pull/94#issuecomment-4955515010): infeasibility is a **solver outcome reported as a status**, not an exception — matching the JuMP/MOI ecosystem convention (solve reports, query throws).

- `minimize` on a provably infeasible model logs a `@warn` and returns `(+Inf, infeasible Solution)` — the minimum over an empty feasible set. `maximize` returns `-Inf` via its existing sign-flip.
- `Solution.tensor` is now `Union{MPS, Nothing}`; new exported predicate `is_infeasible(::Solution)`.
- `sample` on an infeasible solution throws a clear `ArgumentError` (querying a nonexistent result); `Base.in` returns `false`.
- `tensolver_status` gains the `MOI.INFEASIBLE, "infeasible"` branch and `QUBODrivers.sample` returns an empty `SampleSet` for infeasible solutions — ready for the #65 JuMP/MOI constrained integration.
- Both proven-infeasibility sites funnel through one `infeasible_result` helper: the initial-state projection (n ≥ 2) and the n=1 feasible-basis-state search. The *mid-run* zero-amplitude collapse remains an error, since a feasible start means it indicates numerical trouble rather than proven infeasibility.
- Genuine input-validation errors (malformed constraints, bad kwargs) remain exceptions.

## Tests

- `test/constrained_solve.jl`: the previous `@test_throws ArgumentError` infeasibility assertions are replaced by status checks — `E == Inf`, `is_infeasible`, empty stats vectors, `sample` throws, `∉`, `maximize == -Inf`, the n=1 fast path, and the `MOI.INFEASIBLE` mapping. All wrapped in `@test_logs (:warn, …)` so the warning contract is also pinned.
- Full suite green locally.

## Follow-ups unblocked

- #63 — the remaining gap-filling tests can now target the status contract directly.
- #65 — the design doc can reference implemented behavior: native status → `MOI.INFEASIBLE` + `result_count == 0`.

Refs #94, #55.
