### PR TITLE
Document CoTenN-inspired hard constraints (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,31 @@ These vectors are the (approximate) optimal solutions to the original optimizati
 x = TenSolver.sample(psi)
 ```
 
+### Constraints
+
+TenSolver can also enforce **hard constraints** on the binary variables.
+Rather than adding penalty terms to the objective, each constraint is lowered to
+a projection MPO that removes the infeasible subspace exactly, so every sampled
+solution is guaranteed feasible.
+
+```julia
+using TenSolver
+
+# Maximize value while selecting at most two of the three assets.
+values = [3.0, 2.0, 4.0]
+budget = SumConstraint([1, 2, 3], [1, 1, 1], 2; relation = :(<=))
+
+E, psi = TenSolver.minimize(zeros(3, 3), -values; constraints = [budget])
+x = TenSolver.sample(psi)   # always satisfies the budget
+```
+
+The available constraint types are `SumConstraint`, `NotEqualsConstraint`,
+`ExactlyOneConstraint`, and `RelationConstraint`. This projection design is
+adapted from CoTenN (Sharma, Peng, Dangwal, and Achour, *"CoTenN: Constrained
+Optimization with Tensor Networks,"* PLDI 2026). Hard constraints are
+experimental; see the [documentation](https://SECQUOIA.github.io/TenSolver.jl)
+for details.
+
 ### JuMP interface
 
 Alternatively, we also provide an `Optimizer`

--- a/README.md
+++ b/README.md
@@ -3,21 +3,25 @@
 [![Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://SECQUOIA.github.io/TenSolver.jl/stable/)
 [![Documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://SECQUOIA.github.io/TenSolver.jl/dev/)
 
-Tensor Network-based solver for **Q**uadratic **U**nconstrained **B**inary **O**ptimization (QUBO) problems.
+Tensor Network-based solver for binary optimization problems:
+quadratic (QUBO), higher-order polynomial (PUBO), and constrained.
 
 $$\begin{array}{rl}
-  \min_x      & x' Q x \\
-  \text{s.t.} & x \in \mathbb{B}^{n}
+  \min_x      & p(x) \\
+  \text{s.t.} & x \text{ satisfies hard constraints (optional)} \\
+              & x \in \mathbb{B}^{n}
 \end{array}$$
+
+Here `p` may be a quadratic form `x' Q x + l' x + c` or an arbitrary polynomial.
 
 ## Installation
 
-This package is currently not registered. Install it directly from the git url:
+The package is registered in the General registry:
 
 ```julia
 using Pkg
 
-Pkg.add(url="https://github.com/SECQUOIA/TenSolver.jl.git")
+Pkg.add("TenSolver")
 ```
 
 ## Usage
@@ -43,28 +47,17 @@ x = TenSolver.sample(psi)
 
 ### Constraints
 
-TenSolver can also enforce **hard constraints** on the binary variables.
-Rather than adding penalty terms to the objective, each constraint is lowered to
-a projection MPO that removes the infeasible subspace exactly, so every sampled
-solution is guaranteed feasible.
+TenSolver can also enforce hard constraints on the binary variables — every
+sampled solution is guaranteed feasible, with no penalty terms involved:
 
 ```julia
-using TenSolver
-
-# Maximize value while selecting at most two of the three assets.
-values = [3.0, 2.0, 4.0]
 budget = SumConstraint([1, 2, 3], [1, 1, 1], 2; relation = :(<=))
-
-E, psi = TenSolver.minimize(zeros(3, 3), -values; constraints = [budget])
-x = TenSolver.sample(psi)   # always satisfies the budget
+E, psi = TenSolver.maximize(zeros(3, 3), values; constraints = [budget])
 ```
 
-The available constraint types are `SumConstraint`, `NotEqualsConstraint`,
-`ExactlyOneConstraint`, and `RelationConstraint`. This projection design is
-adapted from CoTenN (Sharma, Peng, Dangwal, and Achour, *"CoTenN: Constrained
-Optimization with Tensor Networks,"* PLDI 2026). Hard constraints are
-experimental; see the [documentation](https://SECQUOIA.github.io/TenSolver.jl)
-for details.
+The constraint API is experimental and subject to change; see the
+[constraints documentation](https://SECQUOIA.github.io/TenSolver.jl/dev/constraints/)
+for the available types, the projection method behind them, and worked examples.
 
 ### JuMP interface
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ quadratic (QUBO), higher-order polynomial (PUBO), and constrained.
 
 $$\begin{array}{rl}
   \min_x      & p(x) \\
-  \text{s.t.} & x \text{ satisfies hard constraints (optional)} \\
+  \text{s.t.} & Ax = b \\
+   P x \le q \\
+   x \text{ satisfies other constraints} \\
               & x \in \mathbb{B}^{n}
 \end{array}$$
 
@@ -47,7 +49,7 @@ x = TenSolver.sample(psi)
 
 ### Constraints
 
-TenSolver can also enforce hard constraints on the binary variables — every
+TenSolver can also enforce hard constraints on the binary variables. Every
 sampled solution is guaranteed feasible, with no penalty terms involved:
 
 ```julia

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,7 @@ makedocs(
     pages = [
         "Home" => "index.md",
         "Examples" => "examples.md",
+        "Constraints" => "constraints.md",
         "API Reference" => "api.md",
     ],
     repo = Documenter.Remotes.GitHub("SECQUOIA", "TenSolver.jl"),

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -40,6 +40,11 @@ TenSolver.ising_to_qubo
 
 ## Constraints
 
+Hard constraints are enforced by lowering each one to an exact projection MPO,
+following CoTenN (Sharma, Peng, Dangwal, and Achour, *"CoTenN: Constrained
+Optimization with Tensor Networks,"* PLDI 2026). See [Constrained Optimization](@ref)
+for a worked example.
+
 ```@docs
 TenSolver.AbstractConstraint
 TenSolver.SumConstraint

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -1,0 +1,215 @@
+# Constrained Optimization
+
+Besides the unconstrained objective, TenSolver can enforce **hard constraints**
+on the binary variables. Instead of adding penalty terms to the objective
+(which only discourage infeasible solutions), each constraint is lowered to a
+*projection MPO* that removes the infeasible subspace exactly, so every sampled
+solution is guaranteed feasible.
+
+The projection design is adapted from CoTenN (Sharma, Peng, Dangwal, and
+Achour, *"CoTenN: Constrained Optimization with Tensor Networks,"* PLDI 2026).
+TenSolver implements it as a native Julia lowering built on ITensors — no CoTenN
+code is vendored.
+
+!!! warning "Experimental"
+    Hard constraints are experimental. They are TenSolver's native Julia
+    lowering target; a future JuMP/MOI integration may change which constraint
+    abstraction is considered stable public API.
+
+## How projections work
+
+A solve with `constraints` proceeds in three steps:
+
+1. The objective is turned into an MPO Hamiltonian ``H``, exactly as in the
+   unconstrained case.
+2. Each constraint is lowered to a deterministic finite automaton (DFA) that
+   accepts exactly the feasible bitstrings, and the automaton is threaded into
+   an MPO ``P`` that is **diagonal with entries 1 on feasible basis states and
+   0 on infeasible ones** — an exact projector, not a penalty.
+3. DMRG minimizes the projected Hamiltonian ``P' H P``. Because numerical noise
+   and truncation can leak amplitude back into the (zero-energy) infeasible
+   kernel, the state is re-projected at every iteration, which is what makes
+   every sampled bitstring feasible.
+
+Each of the four built-in constraint types has a specialized automaton with a
+compact bond dimension (see the table below). Other constraints can be lowered
+through a generic path that enumerates the feasible assignments on the
+constrained sites; it is exact as well, but its bond dimension is not bounded a
+priori, so the specialized lowerings are preferred whenever they apply.
+
+The cost driver is the MPO bond dimension: the projected Hamiltonian satisfies
+``\chi(P' H P) \le \chi(H) \cdot \prod_i \chi(P_i)``, so compact projections
+keep constrained solves close to the unconstrained cost.
+
+| Constraint | Enforces | Bond dimension of ``P`` |
+|:-----------|:---------|:------------------------|
+| [`SumConstraint`](@ref) | ``\sum_i w_i \, x_{s_i} \lessgtr b`` | ``b + 2`` (independent of the number of variables) |
+| [`NotEqualsConstraint`](@ref) | ``x_S \ne v`` (one forbidden assignment) | 2 |
+| [`ExactlyOneConstraint`](@ref) | one-hot over selected sites | 2 |
+| [`RelationConstraint`](@ref) | ``x_i \lessgtr x_j`` | 2 |
+
+## Using constraints
+
+Pass a vector of constraints to [`minimize`](@ref) or [`maximize`](@ref)
+through the `constraints` keyword. Here we pick assets to maximize total value
+under a budget that admits at most two of them:
+
+```jldoctest budget
+using TenSolver
+
+# Choose among three assets to maximize value, but a budget admits at most two.
+values = [3.0, 2.0, 4.0]
+budget = SumConstraint([1, 2, 3], [1, 1, 1], 2; relation = :(<=))
+
+E, psi = TenSolver.maximize(zeros(3, 3), values; constraints = [budget], verbosity = 0)
+x = TenSolver.sample(psi)
+
+# The optimum keeps the two most valuable assets (1 and 3), within the budget.
+(E ≈ 7.0, x, is_feasible(x, [budget]))
+
+# output
+
+(true, [1, 0, 1], true)
+```
+
+You can also check an assignment against constraints directly with
+[`is_feasible`](@ref), without solving:
+
+```jldoctest budget
+# Selecting assets 2 and 3 respects the budget; selecting all three does not.
+(is_feasible([0, 1, 1], [budget]), is_feasible([1, 1, 1], [budget]))
+
+# output
+
+(true, false)
+```
+
+## Constraint reference
+
+### SumConstraint
+
+`SumConstraint(sites, weights, rhs; relation)` enforces the weighted sum
+
+```math
+\sum_{i} \texttt{weights}[i] \cdot x_{\texttt{sites}[i]}
+\;\; \texttt{relation} \;\; \texttt{rhs},
+```
+
+with `relation` one of `:(==)`, `:(!=)`, `:(<=)`, or `:(>=)`. The `sites` must
+be unique positive integers, and — a deliberate v1 restriction — `weights` and
+`rhs` must be **nonnegative integers**. Its automaton tracks the capped partial
+sum, so the projection bond dimension is `rhs + 2` regardless of how many
+variables the sum touches. The budget example above is a `SumConstraint`.
+
+### NotEqualsConstraint
+
+`NotEqualsConstraint(sites, values)` forbids a single partial assignment: at
+least one component of ``x[\texttt{sites}]`` must differ from `values`
+(``x_S \ne v``). Bond dimension 2.
+
+```jldoctest noteq
+using TenSolver
+
+# [1, 1] is the unconstrained optimum, but that assignment is forbidden.
+exclude = NotEqualsConstraint([1, 2], [1, 1])
+
+E, psi = TenSolver.minimize(zeros(2, 2), [-2.0, -1.0]; constraints = [exclude], verbosity = 0)
+
+(E ≈ -2.0, TenSolver.sample(psi))
+
+# output
+
+(true, [1, 0])
+```
+
+### ExactlyOneConstraint
+
+`ExactlyOneConstraint(sites, value)` requires exactly one of the selected sites
+to equal `value` (`0` or `1`):
+
+```math
+\#\{\, s \in \texttt{sites} : x_s = \texttt{value} \,\} = 1,
+```
+
+the one-hot constraint familiar from assignment and coloring encodings. Bond
+dimension 2.
+
+```jldoctest onehot
+using TenSolver
+
+# Pick exactly one of the three options; the second is the most valuable.
+one_hot = ExactlyOneConstraint([1, 2, 3], 1)
+
+E, psi = TenSolver.minimize(zeros(3, 3), [-1.0, -3.0, -2.0]; constraints = [one_hot], verbosity = 0)
+
+(E ≈ -3.0, TenSolver.sample(psi))
+
+# output
+
+(true, [0, 1, 0])
+```
+
+### RelationConstraint
+
+`RelationConstraint(left_site, relation, right_site)` enforces the pairwise
+relation ``x_{\texttt{left}} \lessgtr x_{\texttt{right}}`` with the same four
+relations as `SumConstraint`. For binary variables, `:(<=)` reads as an
+implication: selecting the left site forces the right one. Bond dimension 2.
+
+```jldoctest relation
+using TenSolver
+
+# Selecting item 1 requires also selecting item 2 (x1 <= x2).
+implies = RelationConstraint(1, :(<=), 2)
+
+E, psi = TenSolver.minimize(zeros(2, 2), [-2.0, 1.0]; constraints = [implies], verbosity = 0)
+
+# Taking both (-2 + 1 = -1) beats the feasible alternatives [0,0] and [0,1].
+(E ≈ -1.0, TenSolver.sample(psi))
+
+# output
+
+(true, [1, 1])
+```
+
+## Combining constraints
+
+Passing several constraints applies their conjunction — the feasible set is the
+intersection. All four types compose freely:
+
+```jldoctest combined
+using TenSolver
+
+constraints = [
+    SumConstraint([1, 2, 3], [1, 1, 1], 2; relation = :(<=)),
+    NotEqualsConstraint([1, 2], [1, 1]),
+    ExactlyOneConstraint([2, 3], 1),
+    RelationConstraint(1, :(>=), 3),
+]
+
+E, psi = TenSolver.minimize(zeros(3, 3), [-3.0, -2.0, -1.0]; constraints, verbosity = 0)
+x = TenSolver.sample(psi)
+
+(E ≈ -4.0, x, is_feasible(x, constraints))
+
+# output
+
+(true, [1, 0, 1], true)
+```
+
+## Infeasible models
+
+When the constraints admit no feasible assignment at all, the solve does not
+throw — following the convention of other optimization packages, it logs a
+warning and reports the outcome as a status: [`minimize`](@ref) returns `+Inf`
+(the minimum over an empty feasible set) together with an infeasible solution,
+and [`maximize`](@ref) returns `-Inf`. Check with [`is_feasible`](@ref);
+sampling an infeasible solution throws.
+
+```julia
+impossible = [SumConstraint([1, 2], [1, 1], 3; relation = :(==))]
+E, psi = TenSolver.minimize(zeros(2, 2); constraints = impossible)
+
+E                 # +Inf
+is_feasible(psi)  # false
+```

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -34,6 +34,11 @@ A solve with `constraints` proceeds in three steps:
 Each of the four built-in constraint types has a specialized automaton with a
 compact bond dimension (see the table below).
 
+A legacy generic path can enumerate feasible assignments for constraints
+without a DFA lowering. It is exact, but it is the slowest construction and
+its bond dimension can grow with the feasible set, so custom constraints
+should provide an automaton instead.
+
 The cost driver is the MPO bond dimension: the projected Hamiltonian satisfies
 ``\chi(P' H P) \le \chi(H) \cdot \prod_i \chi(P_i)^2``, so compact projections
 keep constrained solves close to the unconstrained cost.
@@ -88,20 +93,22 @@ You can also check an assignment against constraints directly with
 `SumConstraint(sites, weights, rhs; relation)` enforces the weighted sum
 
 ```math
-\sum_{i \in \texttt{sites}} \texttt{weights}[i] \cdot x[i]
+\sum_j \texttt{weights}[j] \cdot x_{\texttt{sites}[j]}
 \;\; \texttt{relation} \;\; \texttt{rhs},
 ```
 
-with `relation` one of `:(==)`, `:(!=)`, `:(<=)`, or `:(>=)`. The `sites` are unique positive integers representing variable indices, while `weights` and
-`rhs` must be **nonnegative integers**. Its automaton tracks the capped partial
-sum, so the projection bond dimension is `rhs + 2` regardless of how many
-variables the sum touches.
+where `sites[j]` and `weights[j]` are paired positionally, and `relation` is one
+of `:(==)`, `:(!=)`, `:(<=)`, or `:(>=)`. The `sites` are unique positive
+integers representing variable indices, while `weights` and `rhs` must be
+**nonnegative integers**. Its automaton tracks the capped partial sum, so the
+projection bond dimension is `rhs + 2` regardless of how many variables the
+sum touches.
 
 ### NotEqualsConstraint
 
 `NotEqualsConstraint(sites, values)` forbids a single partial assignment: at
 least one component of ``x[\texttt{sites}]`` must differ from `values`:
-``\exists i \in \texttt{sites}, x[i] \ne \texttt[i].`` 
+``\exists j,\ x_{\texttt{sites}[j]} \ne \texttt{values}[j].``
 
 Its bond dimension is always 2.
 
@@ -123,8 +130,13 @@ E, psi = TenSolver.minimize(zeros(2, 2), [-2.0, -1.0]; constraints = [exclude], 
 ### ExactlyOneConstraint
 
 `ExactlyOneConstraint(sites, value)` requires exactly one of the selected sites
-to equal `value`:
+to equal `value`, which must be `0` or `1`:
 
+```math
+\#\{\, s \in \texttt{sites} : x_s = \texttt{value} \,\} = 1.
+```
+
+Its specialized automaton has bond dimension 2.
 
 ```jldoctest onehot
 using TenSolver

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -32,20 +32,17 @@ A solve with `constraints` proceeds in three steps:
    every sampled bitstring feasible.
 
 Each of the four built-in constraint types has a specialized automaton with a
-compact bond dimension (see the table below). Other constraints can be lowered
-through a generic path that enumerates the feasible assignments on the
-constrained sites; it is exact as well, but its bond dimension is not bounded a
-priori, so the specialized lowerings are preferred whenever they apply.
+compact bond dimension (see the table below).
 
 The cost driver is the MPO bond dimension: the projected Hamiltonian satisfies
-``\chi(P' H P) \le \chi(H) \cdot \prod_i \chi(P_i)``, so compact projections
+``\chi(P' H P) \le \chi(H) \cdot \prod_i \chi(P_i)^2``, so compact projections
 keep constrained solves close to the unconstrained cost.
 
 | Constraint | Enforces | Bond dimension of ``P`` |
 |:-----------|:---------|:------------------------|
 | [`SumConstraint`](@ref) | ``\sum_i w_i \, x_{s_i} \lessgtr b`` | ``b + 2`` (independent of the number of variables) |
 | [`NotEqualsConstraint`](@ref) | ``x_S \ne v`` (one forbidden assignment) | 2 |
-| [`ExactlyOneConstraint`](@ref) | one-hot over selected sites | 2 |
+| [`ExactlyOneConstraint`](@ref) | ``\mathrm{count}_{i \in S}(x_i = k) = 1`` | 2 |
 | [`RelationConstraint`](@ref) | ``x_i \lessgtr x_j`` | 2 |
 
 ## Using constraints
@@ -91,21 +88,22 @@ You can also check an assignment against constraints directly with
 `SumConstraint(sites, weights, rhs; relation)` enforces the weighted sum
 
 ```math
-\sum_{i} \texttt{weights}[i] \cdot x_{\texttt{sites}[i]}
+\sum_{i \in \texttt{sites}} \texttt{weights}[i] \cdot x[i]
 \;\; \texttt{relation} \;\; \texttt{rhs},
 ```
 
-with `relation` one of `:(==)`, `:(!=)`, `:(<=)`, or `:(>=)`. The `sites` must
-be unique positive integers, and — a deliberate v1 restriction — `weights` and
+with `relation` one of `:(==)`, `:(!=)`, `:(<=)`, or `:(>=)`. The `sites` are unique positive integers representing variable indices, while `weights` and
 `rhs` must be **nonnegative integers**. Its automaton tracks the capped partial
 sum, so the projection bond dimension is `rhs + 2` regardless of how many
-variables the sum touches. The budget example above is a `SumConstraint`.
+variables the sum touches.
 
 ### NotEqualsConstraint
 
 `NotEqualsConstraint(sites, values)` forbids a single partial assignment: at
-least one component of ``x[\texttt{sites}]`` must differ from `values`
-(``x_S \ne v``). Bond dimension 2.
+least one component of ``x[\texttt{sites}]`` must differ from `values`:
+``\exists i \in \texttt{sites}, x[i] \ne \texttt[i].`` 
+
+Its bond dimension is always 2.
 
 ```jldoctest noteq
 using TenSolver
@@ -125,14 +123,8 @@ E, psi = TenSolver.minimize(zeros(2, 2), [-2.0, -1.0]; constraints = [exclude], 
 ### ExactlyOneConstraint
 
 `ExactlyOneConstraint(sites, value)` requires exactly one of the selected sites
-to equal `value` (`0` or `1`):
+to equal `value`:
 
-```math
-\#\{\, s \in \texttt{sites} : x_s = \texttt{value} \,\} = 1,
-```
-
-the one-hot constraint familiar from assignment and coloring encodings. Bond
-dimension 2.
 
 ```jldoctest onehot
 using TenSolver
@@ -200,7 +192,7 @@ x = TenSolver.sample(psi)
 ## Infeasible models
 
 When the constraints admit no feasible assignment at all, the solve does not
-throw — following the convention of other optimization packages, it logs a
+throw, it logs a
 warning and reports the outcome as a status: [`minimize`](@ref) returns `+Inf`
 (the minimum over an empty feasible set) together with an infeasible solution,
 and [`maximize`](@ref) returns `-Inf`. Check with [`is_feasible`](@ref);

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -34,10 +34,6 @@ A solve with `constraints` proceeds in three steps:
 Each of the four built-in constraint types has a specialized automaton with a
 compact bond dimension (see the table below).
 
-A legacy generic path can enumerate feasible assignments for constraints
-without a DFA lowering. It is exact, but it is the slowest construction and
-its bond dimension can grow with the feasible set, so custom constraints
-should provide an automaton instead.
 
 The cost driver is the MPO bond dimension: the projected Hamiltonian satisfies
 ``\chi(P' H P) \le \chi(H) \cdot \prod_i \chi(P_i)^2``, so compact projections
@@ -93,22 +89,20 @@ You can also check an assignment against constraints directly with
 `SumConstraint(sites, weights, rhs; relation)` enforces the weighted sum
 
 ```math
-\sum_j \texttt{weights}[j] \cdot x_{\texttt{sites}[j]}
+\sum_{i \in \texttt{sites}} \texttt{weights}[i] \cdot x[i]
 \;\; \texttt{relation} \;\; \texttt{rhs},
 ```
 
-where `sites[j]` and `weights[j]` are paired positionally, and `relation` is one
-of `:(==)`, `:(!=)`, `:(<=)`, or `:(>=)`. The `sites` are unique positive
-integers representing variable indices, while `weights` and `rhs` must be
-**nonnegative integers**. Its automaton tracks the capped partial sum, so the
-projection bond dimension is `rhs + 2` regardless of how many variables the
-sum touches.
+where `relation` is one of `:(==)`, `:(!=)`, `:(<=)`, or `:(>=)`. The `sites` are unique positive integers representing variable indices, while `weights` and
+`rhs` must be **nonnegative integers**. Its automaton tracks the capped partial
+sum, so the projection bond dimension is `rhs + 2` regardless of how many
+variables the sum touches.
 
 ### NotEqualsConstraint
 
 `NotEqualsConstraint(sites, values)` forbids a single partial assignment: at
 least one component of ``x[\texttt{sites}]`` must differ from `values`:
-``\exists j,\ x_{\texttt{sites}[j]} \ne \texttt{values}[j].``
+``\exists i \in \texttt{sites},\  x[i] \ne \texttt{values}[i].``
 
 Its bond dimension is always 2.
 
@@ -130,7 +124,7 @@ E, psi = TenSolver.minimize(zeros(2, 2), [-2.0, -1.0]; constraints = [exclude], 
 ### ExactlyOneConstraint
 
 `ExactlyOneConstraint(sites, value)` requires exactly one of the selected sites
-to equal `value`, which must be `0` or `1`:
+to equal `value`:
 
 ```math
 \#\{\, s \in \texttt{sites} : x_s = \texttt{value} \,\} = 1.

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -390,3 +390,63 @@ println("Number of conflicts: ", conflicts)
 Graph coloring: [0, 1, 0, 1]
 Number of conflicts: 0.0
 ```
+
+## Constrained Optimization
+
+Besides the unconstrained objective, TenSolver can enforce **hard constraints**
+on the binary variables. Instead of adding penalty terms to the objective (which
+only discourage infeasible solutions), each constraint is lowered to a *projection
+MPO* that removes the infeasible subspace exactly, so every sampled solution is
+guaranteed feasible. This projection approach is adapted from CoTenN (Sharma,
+Peng, Dangwal, and Achour, *"CoTenN: Constrained Optimization with Tensor
+Networks,"* PLDI 2026).
+
+The available constraint types are [`SumConstraint`](@ref), [`NotEqualsConstraint`](@ref),
+[`ExactlyOneConstraint`](@ref), and [`RelationConstraint`](@ref); pass them to
+[`minimize`](@ref) or [`maximize`](@ref) through the `constraints` keyword.
+
+Here we pick assets to maximize total value under a budget that admits at most
+two of them, expressed as a `SumConstraint`:
+
+```jldoctest constraints
+using TenSolver
+
+# Choose among three assets to maximize value, but a budget admits at most two.
+values = [3.0, 2.0, 4.0]
+budget = SumConstraint([1, 2, 3], [1, 1, 1], 2; relation = :(<=))
+
+# Maximizing value is minimizing the negative value, subject to the budget.
+E, psi = TenSolver.minimize(zeros(3, 3), -values; constraints = [budget], verbosity = 0)
+x = TenSolver.sample(psi)
+
+# The optimum keeps the two most valuable assets (1 and 3), within the budget.
+(E ≈ -7.0, x, is_feasible(x, [budget]))
+
+# output
+
+(true, [1, 0, 1], true)
+```
+
+You can also check an assignment against a set of constraints directly with
+[`is_feasible`](@ref), without solving:
+
+```jldoctest constraints
+# Selecting assets 2 and 3 respects the budget; selecting all three does not.
+(is_feasible([0, 1, 1], [budget]), is_feasible([1, 1, 1], [budget]))
+
+# output
+
+(true, false)
+```
+
+Constraints compose: passing several of them applies their conjunction. When the
+constraints admit no feasible assignment at all, the solve does not error — it
+returns `+Inf` (`-Inf` for [`maximize`](@ref)) together with an infeasible
+solution, which you can detect with [`is_feasible`](@ref) and which cannot be
+sampled.
+
+!!! note
+    Hard constraints are experimental. The bond dimension of a `SumConstraint`
+    projection grows only with its right-hand side (`rhs + 2`), independent of the
+    number of variables, so capacity-style constraints stay cheap; the other v1
+    constraint types use bond dimension 2.

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -391,62 +391,9 @@ Graph coloring: [0, 1, 0, 1]
 Number of conflicts: 0.0
 ```
 
-## Constrained Optimization
+## Constraints
 
-Besides the unconstrained objective, TenSolver can enforce **hard constraints**
-on the binary variables. Instead of adding penalty terms to the objective (which
-only discourage infeasible solutions), each constraint is lowered to a *projection
-MPO* that removes the infeasible subspace exactly, so every sampled solution is
-guaranteed feasible. This projection approach is adapted from CoTenN (Sharma,
-Peng, Dangwal, and Achour, *"CoTenN: Constrained Optimization with Tensor
-Networks,"* PLDI 2026).
-
-The available constraint types are [`SumConstraint`](@ref), [`NotEqualsConstraint`](@ref),
-[`ExactlyOneConstraint`](@ref), and [`RelationConstraint`](@ref); pass them to
-[`minimize`](@ref) or [`maximize`](@ref) through the `constraints` keyword.
-
-Here we pick assets to maximize total value under a budget that admits at most
-two of them, expressed as a `SumConstraint`:
-
-```jldoctest constraints
-using TenSolver
-
-# Choose among three assets to maximize value, but a budget admits at most two.
-values = [3.0, 2.0, 4.0]
-budget = SumConstraint([1, 2, 3], [1, 1, 1], 2; relation = :(<=))
-
-# Maximizing value is minimizing the negative value, subject to the budget.
-E, psi = TenSolver.minimize(zeros(3, 3), -values; constraints = [budget], verbosity = 0)
-x = TenSolver.sample(psi)
-
-# The optimum keeps the two most valuable assets (1 and 3), within the budget.
-(E ≈ -7.0, x, is_feasible(x, [budget]))
-
-# output
-
-(true, [1, 0, 1], true)
-```
-
-You can also check an assignment against a set of constraints directly with
-[`is_feasible`](@ref), without solving:
-
-```jldoctest constraints
-# Selecting assets 2 and 3 respects the budget; selecting all three does not.
-(is_feasible([0, 1, 1], [budget]), is_feasible([1, 1, 1], [budget]))
-
-# output
-
-(true, false)
-```
-
-Constraints compose: passing several of them applies their conjunction. When the
-constraints admit no feasible assignment at all, the solve does not error — it
-returns `+Inf` (`-Inf` for [`maximize`](@ref)) together with an infeasible
-solution, which you can detect with [`is_feasible`](@ref) and which cannot be
-sampled.
-
-!!! note
-    Hard constraints are experimental. The bond dimension of a `SumConstraint`
-    projection grows only with its right-hand side (`rhs + 2`), independent of the
-    number of variables, so capacity-style constraints stay cheap; the other v1
-    constraint types use bond dimension 2.
+TenSolver can also enforce hard constraints on the binary variables, so every
+sampled solution is guaranteed feasible. This is a larger topic with its own
+page — see [Constrained Optimization](@ref) for the projection method behind it,
+the available constraint types, and worked examples.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -9,6 +9,7 @@ TenSolver.jl provides an efficient solver for QUBO problems using tensor network
 - Solving large-scale binary optimization problems
 - Finding approximate solutions to NP-hard problems
 - Exploring the solution space of combinatorial optimization problems
+- Enforcing hard constraints exactly through projection, without penalty terms
 - GPU-accelerated optimization
 
 ## Installation
@@ -60,6 +61,7 @@ x = TenSolver.sample(psi)
 
 - **Tensor Network Optimization**: Uses advanced tensor network methods (DMRG) for efficient optimization
 - **Probability Distribution**: Returns a probability distribution over optimal solutions
+- **Hard Constraints**: Enforces constraints exactly via CoTenN-style projection MPOs, so sampled solutions are always feasible (see [Constrained Optimization](@ref))
 - **JuMP Integration**: Works seamlessly with the JuMP modeling language
 - **GPU Support**: Supports GPU acceleration via CUDA.jl, Metal.jl, and other accelerators
 - **Flexible Configuration**: Numerous parameters to control accuracy vs. performance trade-off

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 # TenSolver.jl
 
-Tensor Network-based solver for **Q**uadratic **U**nconstrained **B**inary **O**ptimization (QUBO) problems.
+Tensor Network-based solver for binary optimization problems — quadratic (QUBO), higher-order polynomial (PUBO), and constrained.
 
 ## Overview
 
@@ -69,6 +69,6 @@ x = TenSolver.sample(psi)
 ## Contents
 
 ```@contents
-Pages = ["examples.md", "api.md"]
+Pages = ["examples.md", "constraints.md", "api.md"]
 Depth = 2
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 # TenSolver.jl
 
-Tensor Network-based solver for binary optimization problems — quadratic (QUBO), higher-order polynomial (PUBO), and constrained.
+Tensor Network-based solver for binary optimization problems: quadratic (QUBO), higher-order polynomial (PUBO), and constrained.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Documents the CoTenN-inspired hard-constraint feature (#64): a dedicated docs page with the projection narrative and per-type reference, a visible CoTenN citation, and README/index updates reframing TenSolver beyond QUBO-only.

## Changes

- **`docs/src/constraints.md`** (new page, in the nav between Examples and API Reference):
  - *How projections work* — objective MPO `H`; constraint → DFA → exact diagonal 0/1 projector `P`; DMRG on `P' H P` with per-iteration re-projection; specialized compact automata vs the generic feasible-assignment lowering; native Julia port of the CoTenN design (Sharma, Peng, Dangwal, and Achour, PLDI 2026), no vendored code.
  - Bond-dimension table, then a per-type reference: mathematical formulation → constructor mapping, restrictions (e.g. nonnegative integer weights/rhs for `SumConstraint`), expected bond dimension, and a doctested example for each of the four constraint types.
  - Combined-constraints (all four at once) and infeasibility-as-status sections; the budget example uses `maximize` directly.
- **`docs/src/examples.md`** — the constraints material is a three-line pointer to the new page.
- **`README.md`** — reframed from "QUBO solver" to binary optimization (QUBO / PUBO / constrained) with a generalized math display; constraints subsection slimmed to a snippet + "experimental and subject to change" + direct link to the constraints page; stale "not registered" install note fixed to `Pkg.add("TenSolver")`.
- **`docs/src/index.md`** — headline and Features updated; Contents includes the new page.
- **`docs/src/api.md`** — citation note in the Constraints section pointing to the new page.

## Verification

- `docs/make.jl` builds clean with doctests enabled; every `jldoctest` output on the new page was verified against live solver runs (two identical repetitions) before being written down.
- All `@ref` cross-references resolve.

Closes #64.

Note: the "link to the #66 benchmark" item from the issue is intentionally left for when #66 produces something; it does not block the documentation.
