### PR TITLE
Design JuMP/MOI constrained optimization integration

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -13,6 +13,9 @@ The documentation is built using [Documenter.jl](https://github.com/JuliaDocs/Do
 Internal developer notes live outside the generated user documentation:
 
 - **SpinGlassPEPS Integration** (`docs/internal/spinglasspeps_integration.md`): Planned architecture for the optional structured PEPS backend
+- **JuMP/MOI Constraints Integration** (`docs/internal/jump_moi_constraints.md`):
+  Planned lowering from MOI function-in-set constraints to TenSolver's native
+  projection IR
 
 ## Building Documentation Locally
 

--- a/docs/internal/jump_moi_constraints.md
+++ b/docs/internal/jump_moi_constraints.md
@@ -1,11 +1,12 @@
 # JuMP/MOI Constrained Optimization Architecture
 
 This note defines how a future JuMP/MathOptInterface (MOI) front end should
-lower constrained binary models into TenSolver's native projection-constraint
-pipeline. It is an implementation design, not a description of behavior in the
-current release. In particular, `TenSolver.Optimizer` still accepts
-QUBO models and fixed binary variables, but not the general hard constraints
-described here.
+lower constrained finite-domain models into TenSolver's native
+projection-constraint pipeline. It is an implementation design, not a
+description of behavior in the current release. The direct Julia API already
+solves quadratic and polynomial objectives over a uniform finite domain, while
+`TenSolver.Optimizer` still accepts only Boolean QUBO models and fixed Boolean
+variables and does not accept the general hard constraints described here.
 
 The central decision is to keep two layers with different responsibilities:
 
@@ -31,18 +32,23 @@ projection MPO, and solves in the projected space. The four v1 native types are:
 - `RelationConstraint`.
 
 The JuMP path stops earlier. `TenSolver.Optimizer` is generated with
-`QUBODrivers.@setup`, and QUBODrivers defines an `AbstractSampler` as an
-unconstrained QUBO/Ising optimizer, apart from variable-domain and fixed-value
-constraints. Its generic `MOI.supports_constraint` fallback rejects other
-constraint types. `QUBODrivers.sample` in TenSolver then extracts only QUBO
-objective data with `QUBOTools.qubo` and calls `minimize` without a
-`constraints` argument. Consequently, JuMP rejects an affine hard constraint
-before `optimize!` reaches TenSolver.
+`QUBODrivers.@setup`, and QUBODrivers defines an `AbstractSampler` around a
+Boolean QUBO/Ising model, apart from fixed-value constraints. Its generic
+`MOI.supports_constraint` fallback rejects other constraint types.
+`QUBODrivers.sample` in TenSolver then extracts only QUBO objective data with
+`QUBOTools.qubo` and calls `minimize` without a `domain`, `constraints`, or
+`backend` argument. Consequently, the current JuMP path cannot represent the
+finite-domain work from #105/#67, the hard constraints from #62, the backend
+selection planned in #44, or the polynomial objectives requested in #68.
 
-This split is useful: QUBODrivers should continue owning QUBO objective storage,
-sampler attributes, samples, and common MOI result plumbing. TenSolver should
-own the additional hard-constraint store, MOI-to-native normalization, and
-constraint-aware status overrides.
+That generated sampler remains a useful compatibility adapter for Boolean
+quadratic models, solver attributes, `SampleSet` construction, and common MOI
+result behavior. It must not become the authoritative model store for the
+expanded interface. TenSolver should own the full MOI model, domain and
+objective normalization, native-constraint lowering, backend selection, and
+status mapping. If that implementation exposes a generally useful optimizer
+storage or result hook, contribute the narrow hook to QUBODrivers; keep
+TenSolver-specific domains, constraints, and backend rules in TenSolver.
 
 ## Public API Decision
 
@@ -61,58 +67,87 @@ Both layers therefore remain public, but only the MOI layer should grow
 modeling conveniences and bridges. New native types should be added only when
 they define a useful projection target, normally with a specialized DFA.
 
+MOI's function-in-set vocabulary supplies the modeling abstraction required by
+the bridge. Numerical point-projection helpers such as
+`MOI.Utilities.distance_to_set` do not construct a Hilbert-space projection MPO
+and are not part of this implementation; no set-distance dependency is needed.
+
 ## Model-Ingestion Flow
 
-The constrained optimizer should preserve QUBODrivers' non-incremental
-`MOI.copy_to` architecture and specialize it for `TenSolver.Optimizer`:
+The constrained optimizer should use a TenSolver-owned, non-incremental
+`MOI.copy_to` path:
 
 1. JuMP stores the source model in its normal MOI caching optimizer.
-2. TenSolver's concrete `MOI.copy_to(::Optimizer, src)` inventories domain,
-   fixed-variable, objective, and supported hard-constraint data.
-3. A `MOI.Utilities.ModelFilter` hides only the hard constraints that TenSolver
-   will lower. It must retain `VariableIndex`-in-`ZeroOne`, fixed-variable
-   `VariableIndex`-in-`EqualTo`, the objective, and relevant model and variable
-   attributes.
-4. The filtered view is materialized into a fresh `MOI.Utilities.Model{T}`.
-   This extra copy is required because `ModelFilter` filters query results but
-   does not itself advertise `supports_constraint`; QUBODrivers uses that query
-   to identify the binary domain. TenSolver records the source-to-filtered
-   `MOI.IndexMap`.
-5. The materialized model is passed to the QUBODrivers `AbstractSampler` copy
-   path, which keeps ownership of QUBO construction and fixed-variable
-   objective substitution. TenSolver composes this second index map with the
-   first.
-6. TenSolver substitutes those same fixed values into each hard constraint,
-   simplifies the result, lowers it to native constraints, and maps every
-   remaining source `MOI.VariableIndex` through the composed map to the
-   free-variable site returned by `QUBOTools.index`.
-7. The native constraints are stored in an unexported, typed optimizer
-   attribute. `MOI.empty!` resets that store along with the QUBODrivers model.
-8. `QUBODrivers.sample(::Optimizer)` reads the stored native constraints and
-   passes them to `minimize(...; constraints)`.
+2. TenSolver's concrete `MOI.copy_to(::Optimizer, src)` copies the complete
+   queryable model into a TenSolver-owned `MOI.Utilities` model store and
+   returns its source-to-local `MOI.IndexMap`. `MOI.empty!` resets that store,
+   cached execution data, and result state together.
+3. Before solving, TenSolver inventories each variable's domain without
+   assuming `ZeroOne`. `ZeroOne` normalizes to `[0, 1]`; other supported finite
+   sets normalize to their explicit values. The current DMRG API requires one
+   uniform finite real domain, so heterogeneous domains remain stored correctly
+   but produce a typed backend-capability error until #67 adds per-variable
+   domains.
+4. An objective adapter normalizes the objective independently of constraints.
+   Boolean quadratic data may reuse QUBOTools/QUBODrivers conversion, while the
+   shared store leaves a direct path for #68 to lower a polynomial JuMP
+   objective to the existing `AbstractPolynomial` API without creating another
+   optimizer or model cache.
+5. Fixed values are validated against their declared domains and substituted
+   into both the objective and hard constraints. TenSolver records the mapping
+   from surviving MOI variables to native solver sites.
+6. Hard constraints are canonicalized only after domains and fixed values are
+   known. Domain-independent patterns lower directly; target-specific
+   restrictions, such as `SumConstraint` requiring a nonnegative integer
+   domain, are checked by the native lowering layer.
+7. The selected backend is normalized through the existing backend interface.
+   TenSolver validates its objective, domain, constraint, and topology
+   capabilities before calling `minimize`; unsupported combinations raise
+   `ConstraintUnsupportedByBackend` or the corresponding typed capability
+   error rather than silently changing backend.
+8. The solve result is translated into standard MOI status and primal
+   attributes. The Boolean quadratic compatibility path may still construct a
+   QUBOTools `SampleSet`, but that adapter does not define the model's accepted
+   domains or objective classes.
 
-This plan uses public MOI filtering and QUBODrivers dispatch rather than calling
-QUBODrivers' private objective-copy helpers. Access to the internal store should
-be isolated behind TenSolver helpers and covered by a QUBODrivers conformance
-test. If the generated optimizer cannot host an unexported typed attribute
-without relying on undocumented fields, the prerequisite is a small
-QUBODrivers extension hook; the fallback is not a global side table keyed by
-optimizer identity.
+This ownership avoids a constraint side table attached to generated sampler
+internals and removes the need to hide constraints from a QUBODrivers copy.
+TenSolver may reuse public QUBODrivers attributes and result helpers or request
+a small generic upstream hook, but it must not call private objective-copy
+helpers or move projection-specific semantics into QUBODrivers.
 
-The optimizer should also retain the original MOI functions and sets needed to
-answer `NumberOfConstraints`, `ListOfConstraintIndices`, `ConstraintFunction`,
-`ConstraintSet`, and `is_valid`. The native constraints are execution data, not
-a substitute for the MOI model's queryable representation. Its returned
-`MOI.IndexMap` must include the separately stored hard-constraint indices as
-well as the objective/domain indices copied by QUBODrivers.
+The stored MOI model answers `NumberOfConstraints`,
+`ListOfConstraintIndices`, `ConstraintFunction`, `ConstraintSet`, and
+`is_valid`. Native constraints are execution data, not a substitute for the
+MOI model's queryable representation.
+
+### Variable domains
+
+The first front end should recognize domains independently from objectives and
+hard constraints:
+
+- `VariableIndex`-in-`ZeroOne` normalizes to `[0, 1]`;
+- `VariableIndex`-in-`Integer` combined with finite integral bounds normalizes
+  to the enumerated integer values;
+- a TenSolver `FiniteDomain(values)` set represents spin, sparse integer,
+  fractional, or other explicit finite real domains; and
+- `VariableIndex`-in-`EqualTo(value)` fixes a variable but does not replace its
+  declared domain.
+
+Multiple domain constraints are intersected. An empty intersection is a static
+infeasibility result; an unbounded `Integer` or continuous interval is an
+unsupported domain. The current DMRG handoff requires all surviving variables
+to have the same normalized domain. This restriction is checked after the MOI
+model is stored so #67 can later add heterogeneous domains without changing the
+front-end representation.
 
 ### Fixed variables and static simplification
 
-QUBODrivers can remove fixed variables from the sampled QUBO. Constraint
-lowering must therefore substitute fixed values before assigning native site
-numbers. For example, fixing `x[1] = 1` turns `x[1] + x[2] <= 1` into
-`x[2] <= 0`; referring to the old first site after QUBODrivers removes it would
-constrain the wrong variable.
+Objective normalization can remove fixed variables from the sampled problem.
+Constraint lowering must therefore substitute fixed values before assigning
+native site numbers. For example, fixing `x[1] = 1` turns
+`x[1] + x[2] <= 1` into `x[2] <= 0`; referring to the old first site after
+removal would constrain the wrong variable.
 
 After substitution, lowering produces one of three results:
 
@@ -138,9 +173,11 @@ moves `c` into the set bound. For example,
 `MOI.GreaterThan`, `MOI.EqualTo`, and both sides of `MOI.Interval` are handled
 analogously.
 
-The v1 native sum projection accepts nonnegative integer weights and a
-nonnegative integer right-hand side. The MOI bridge must preserve that
-contract:
+Canonicalization itself is domain-neutral. It must not recognize Boolean-only
+identities until the variables' domains are known. The current native sum
+projection accepts nonnegative integer weights and bounds and only lowers over
+a nonnegative integer domain. The native adapter must preserve that narrower
+target contract:
 
 - coefficients and normalized bounds must be exactly integer-valued; the
   bridge must not round approximately integral floating-point data;
@@ -152,85 +189,70 @@ contract:
   integer domain must express the equivalent shifted non-strict bound
   explicitly.
 
-Specialized compact patterns are selected before the general sum fallback.
-This is part of correctness for the performance contract, not a cosmetic
-optimization.
+After domain normalization, specialized compact patterns are selected before
+the general sum fallback. For example, `sum(x) == 1` is exactly-one only for a
+domain where that predicate is equivalent to exactly one site taking the
+target value. These simplifications belong to TenSolver's native lowering, not
+the MOI ingestion layer. This is part of correctness for the performance
+contract, not a cosmetic optimization.
 
 A genuine two-sided bound `l <= sum(a[i] * x[i]) <= u` should likewise use one
 specialized projection rather than compose separate lower- and upper-bound
-projectors. A future `SumIntervalConstraint` can use partial-sum states
-`0:u+1`, send every sum above `u` to the overflow state `u+1`, and accept
-states `l:u`. Its projection MPO therefore has bond at most `u + 2`, instead of
-the product of the two one-sided bonds. This compact DFA justifies a native
-type under the public-API rule above. Normalization should still reduce an
-interval with a redundant side to the existing one-sided `SumConstraint`, or
-report static infeasibility when its bounds cannot contain a reachable sum.
+projectors. Extend `SumConstraint` with a two-sided relation variant that
+stores both closed bounds. Its `constraint_to_dfa` method uses partial-sum
+states `0:u+1`, sends every sum above `u` to the overflow state `u+1`, and
+accepts states `l:u`. The projection MPO therefore has bond at most `u + 2`,
+instead of the product of the two one-sided bonds. A separate
+`SumIntervalConstraint` would duplicate the same weighted-sum abstraction and
+is not needed. Normalization should still reduce an interval with a redundant
+side to the existing one-sided relation, or report static infeasibility when
+its bounds cannot contain a reachable sum.
 
 ## Initial Mapping Table
 
-All rows below require `ZeroOne` variables. “Bond” is the expected projection
-MPO bond bound after lowering, based on the current native DFA methods or, for
-the future interval target, the specialized DFA specified above.
+The MOI store and the table make no blanket `ZeroOne` assumption. Each row
+states the domain required by its current native target. “Bond” is the expected
+projection-MPO bond bound per native constraint after lowering; `|U|` is the
+size of the uniform finite domain.
 
 | MOI/JuMP form | Native lowering | Bond | Conditions and notes |
 |:--------------|:----------------|:-----|:---------------------|
-| `ScalarAffineFunction`-in-`EqualTo(1)`, all unit coefficients | `ExactlyOneConstraint(sites, 1)` | 2 | Prefer this over a general sum. |
-| `sum(x) == length(x) - 1` | `ExactlyOneConstraint(sites, 0)` | 2 | Exactly one selected site is zero. |
-| `x[i] + x[j] <= 1` | `NotEqualsConstraint([i, j], [1, 1])` | 2 | Compact pairwise exclusion. |
-| Nonnegative integer affine function in `EqualTo`, `LessThan`, or `GreaterThan` | `SumConstraint` with `==`, `<=`, or `>=` | `rhs + 2` | Constants are moved into `rhs`; reject invalid normalized data. |
-| Nonnegative integer affine function in `Interval` | Future `SumIntervalConstraint` | `upper + 2` | Use one two-sided partial-sum DFA; simplify a redundant side to a one-sided `SumConstraint`. |
-| `x[i] - x[j]` in `EqualTo(0)`, `LessThan(0)`, or `GreaterThan(0)` | `RelationConstraint(i, relation, j)` | 2 | Covers equality, implication-style `<=`, and `>=`. |
-| `VectorOfVariables([x[i], x[j]])` in `MOI.AllDifferent(2)` | `RelationConstraint(i, :(!=), j)` | 2 | `AllDifferent` over more than two binary variables is statically infeasible. |
-| `VectorOfVariables(x)` in `MOI.SOS1(weights)` | `SumConstraint(sites, ones, 1; relation = :(<=))` | 3 | `SOS1` means *at most* one nonzero, not exactly one; ordering weights do not change feasibility. |
-| `ScalarAffineFunction` in a TenSolver `NotEqualTo(value)` set | `SumConstraint(...; relation = :(!=))`, or `RelationConstraint` for a pairwise pattern | Native target's bound | MOI has no standard scalar not-equal set. |
-| `VectorOfVariables(x)` in a TenSolver `ForbiddenAssignment(values)` set | `NotEqualsConstraint(sites, values)` | 2 | Compact custom set for excluding one bit pattern. |
-| `VariableIndex` in `EqualTo(0 or 1)` | Existing QUBODrivers fixed-variable path | No projector | Substitute before hard-constraint lowering. |
+| Nonnegative integer affine function in `EqualTo`, `LessThan`, or `GreaterThan` | `SumConstraint` with `==`, `<=`, or `>=` | `rhs + 2` | Requires a uniform nonnegative integer domain and exactly integral normalized coefficients/bounds. |
+| Nonnegative integer affine function in `Interval` | `SumConstraint` with a two-sided relation | `upper + 2` | Same domain contract; use one capped DFA and simplify a redundant side to a one-sided relation. |
+| `x[i] - x[j]` in `EqualTo(0)`, `LessThan(0)`, or `GreaterThan(0)` | `RelationConstraint(i, relation, j)` | `|U|` | Domain-independent for a common ordered finite real domain. |
+| `VectorOfVariables(x)` in `MOI.AllDifferent(length(x))` | One `RelationConstraint(i, :(!=), j)` per pair | `|U|` each | Domain-independent; statically infeasible when `length(x) > |U|`. |
+| `VectorOfVariables(x)` in a TenSolver `ExactlyOneValue(value)` set | `ExactlyOneConstraint(sites, value)` | 2 | Any uniform finite domain; a target outside the domain is statically infeasible. |
+| `VectorOfVariables(x)` in `MOI.SOS1(weights)` | Domain-aware lowering | 3 for `U = {0,1}` | Boolean domains lower to `SumConstraint(..., <=, 1)`; other domains are unsupported until a compact at-most-one-nonzero target exists. |
+| `ScalarAffineFunction` in a TenSolver `NotEqualTo(value)` set | `SumConstraint(...; relation = :(!=))`, or `RelationConstraint` for a pairwise pattern | Native target's bound | General sums retain the sum target's domain restrictions. |
+| `VectorOfVariables(x)` in a TenSolver `ForbiddenAssignment(values)` set | `NotEqualsConstraint(sites, values)` | 2 | Any uniform finite domain; values outside the domain make the constraint a tautology. |
+| `VariableIndex` in `EqualTo(value)` | Fixed-value substitution | No projector | Validate `value` against the declared finite domain before lowering. |
 
-Exactly-one should normally be modeled as `sum(x) == 1`. Combining that
-equality with `SOS1` is redundant and would create a second projector. A bare
-`SOS1` cannot lower to `ExactlyOneConstraint` because the all-zero assignment
-is feasible for `SOS1`.
+Once the domain is known, the native simplifier may recover compact Boolean
+identities: `sum(x) == 1` and `sum(x) == length(x)-1` become
+`ExactlyOneConstraint` targets, and `x[i] + x[j] <= 1` becomes a forbidden
+assignment. They are not valid domain-independent MOI rewrites. A bare `SOS1`
+cannot lower to `ExactlyOneConstraint` because the all-zero assignment is
+feasible for `SOS1`.
 
-The custom `NotEqualTo` and `ForbiddenAssignment` sets belong to the MOI front
-end. They do not replace `SumConstraint` or `NotEqualsConstraint`; they provide
-standard function-in-set syntax for native targets that have no lossless
+The custom `ExactlyOneValue`, `NotEqualTo`, and `ForbiddenAssignment` sets
+belong to the MOI front end. They do not replace native constraint types; they
+provide function-in-set syntax for projection targets that have no lossless
 off-the-shelf MOI set.
-
-## Point-on-Set Versus Projection MPOs
-
-MOI's function-in-set vocabulary is the right abstraction for declaring the
-feasible set. It should not be confused with the operator that TenSolver builds.
-
-`MOI.Utilities.distance_to_set` and the separate
-[MathOptSetDistances.jl](https://github.com/matbesancon/MathOptSetDistances.jl)
-package operate on numeric points and MOI sets. They can support validation or
-diagnostics, but they do not construct TenSolver's projection MPO. TenSolver's
-`P` is a Hilbert-space operator that is diagonal in the binary computational
-basis, with value one on feasible bitstrings and zero on infeasible bitstrings.
-
-Therefore the first bridge needs no new set-distance dependency. The useful
-connection is conceptual: the MOI set defines membership, the native constraint
-defines a compact automaton for that membership predicate, and the automaton
-defines `P`.
-
-This separation also leaves room for future non-diagonal projections, such as
-the eigenvalue constraints discussed in the CoTenN work, without pretending
-that every projection MPO is a Euclidean point projection.
 
 ## Unsupported Constraints and Fallback Policy
 
 The default policy is an explicit hard error. The v1 bridge must not silently:
 
 - convert a hard constraint into a penalty QUBO;
-- enumerate every feasible assignment through the legacy generic projection
-  path; or
-- accept a bridge that introduces continuous, general-integer, or otherwise
-  non-binary auxiliary variables.
+- introduce exhaustive feasible-assignment enumeration as a fallback; or
+- accept a bridge that introduces a continuous, infinite, or unspecified
+  domain that the selected backend cannot represent.
 
 Penalty conversion changes the optimization problem unless a safe penalty
-scale is known. Generic feasible-path enumeration preserves semantics but can
-have exponentially larger bonds and is slated for removal in favor of explicit
-automata. Neither is an acceptable implicit fallback.
+scale is known. Exhaustive feasible-path enumeration can preserve semantics but
+can have exponentially larger bonds; no such fallback exists in the current
+code, and this design does not reintroduce it. Neither behavior is acceptable
+implicitly.
 
 For unsupported function/set *types*, `MOI.supports_constraint` returns false,
 allowing MOI to try a registered bridge and otherwise raise
@@ -254,12 +276,13 @@ that the default remains hard-error behavior.
 TenSolver should advertise direct support for each row in the mapping table so
 MOI does not replace a compact pattern with a generic MILP bridge. Other MOI
 bridges may be used only when their output consists entirely of supported
-binary functions and sets. Every introduced variable must have a `ZeroOne`
-domain before the model reaches native lowering.
+functions and explicit finite-domain sets. A bridge must not silently replace a
+declared domain with `ZeroOne`; every introduced variable carries a domain that
+the selected backend validates.
 
 Bridge output is canonicalized exactly like user-authored constraints. The
-bridge boundary cannot bypass integer, nonnegativity, fixed-variable, or
-backend checks.
+bridge boundary cannot bypass domain, integer, nonnegativity, fixed-variable,
+objective, or backend checks.
 
 The projection layer remains MOI-agnostic. No method in `projection_mpo.jl`
 should accept an MOI function or set.
@@ -278,13 +301,15 @@ The MOI layer maps that outcome to:
 - `MOI.TerminationStatus() == MOI.INFEASIBLE`;
 - `MOI.ResultCount() == 0`;
 - `MOI.PrimalStatus() == MOI.NO_SOLUTION`; and
-- an empty QUBOTools `SampleSet` with the TenSolver status in metadata.
+- no variable primal values.
 
 TenSolver already computes `MOI.INFEASIBLE` in `tensolver_status`, but the
 generic QUBODrivers termination-status getter treats a nonempty metadata object
 with zero samples as `MOI.OTHER_ERROR`. The constrained implementation must add
 a concrete `MOI.get(::Optimizer, ::MOI.TerminationStatus)` override that reads
-TenSolver's recorded status. Metadata alone does not complete the MOI contract.
+TenSolver's recorded status. The Boolean quadratic compatibility adapter also
+returns an empty QUBOTools `SampleSet` with that status in metadata. Metadata
+alone does not complete the MOI contract.
 
 Invalid model data and unsupported backends do not map to `INFEASIBLE`: they
 remain typed construction or solve errors. Constraint duals are unsupported.
@@ -295,6 +320,14 @@ remain typed construction or solve errors. Constraint duals are unsupported.
   `minimize`/`maximize` path and native `constraints` keyword.
 - #64 is complete. Its public constraints page defines the native vocabulary
   and measured projection costs used by this design.
+- #105 and the subsequent #106/#109 domain work are on `main`. The MOI store is
+  therefore finite-domain-neutral, while the first backend adapter targets the
+  uniform-domain contract currently implemented by DMRG. Per-variable domains
+  remain coordinated through #67.
+- #44 is the pending optional-backend integration. Backend selection is part of
+  model normalization, and every backend must explicitly advertise supported
+  objective, domain, constraint, and topology combinations. The MOI front end
+  must not assume DMRG or silently fall back to it.
 - #68 should reuse the same MOI ingestion layer for polynomial objectives. A
   future objective adapter may accept PolyJuMP data or a polynomial subset of
   `MOI.ScalarNonlinearFunction`, but it must not create a second optimizer or a
@@ -310,29 +343,33 @@ remain typed construction or solve errors. Constraint duals are unsupported.
 
 The implementation should be split into reviewable stages:
 
-1. **Lowering core and typed errors**: add canonical affine normalization,
-   fixed-value substitution, specialized-pattern recognition, the compact
-   two-sided sum projector, a static infeasibility sentinel, and unit tests
+1. **Optimizer storage and domain inventory**: add the TenSolver-owned MOI model
+   store, `supports_constraint`, `copy_to`, `empty!`, query methods, explicit
+   finite-domain normalization, and compatibility tests for existing
+   QUBODrivers attributes and Boolean QUBO behavior.
+2. **Objective and backend handoff**: normalize quadratic objectives through
+   the existing adapter, preserve one extension point for #68 polynomial
+   objectives, select the backend explicitly, and map surviving MOI variables
+   to native sites after fixed-value substitution.
+3. **Lowering core and typed errors**: add canonical affine normalization,
+   domain-aware specialized-pattern recognition, the two-sided
+   `SumConstraint` relation, a static infeasibility sentinel, and unit tests
    that compare each native result with the source MOI predicate.
-2. **Optimizer storage and copy path**: add the internal MOI/native constraint
-   store, the concrete `supports_constraint`, `copy_to`, `empty!`, and query
-   methods, and the filtered-model materialization plus composed-index-map
-   handoff to QUBODrivers.
-3. **Standard and custom sets**: implement the supported standard mapping rows,
-   then add `NotEqualTo` and `ForbiddenAssignment` with JuMP syntax and MOI
-   conformance tests.
-4. **Solve and status integration**: pass native constraints through
-   `QUBODrivers.sample`, add concrete status getters, and verify empty-result
-   infeasibility behavior.
-5. **End-to-end documentation and tests**: add JuMP examples for weighted sums,
-   exactly-one, pairwise exclusion/relation, infeasibility, fixed variables,
-   and every rejection path. Compare small solutions against brute force and
-   the direct native API.
+4. **Standard and custom sets**: implement the supported standard mapping rows,
+   then add `ExactlyOneValue`, `NotEqualTo`, and `ForbiddenAssignment` with JuMP
+   syntax and MOI conformance tests.
+5. **Solve, status, and end-to-end coverage**: pass the normalized domain and
+   native constraints to the selected backend, add concrete status/primal
+   getters, and add JuMP examples for weighted sums, exactly-one, pairwise
+   exclusion/relation, infeasibility, fixed variables, and every rejection
+   path.
 
-Each stage must preserve unconstrained QUBODrivers behavior. The test matrix
-should include direct MOI use, JuMP's caching/bridge optimizer, model reuse after
-`empty!`, fixed variables, maximization, unsupported sets, and a constraint that
-becomes contradictory only after fixed-variable substitution.
+Each stage must preserve existing unconstrained QUBODrivers behavior. The test
+matrix should include direct MOI use, JuMP's caching/bridge optimizer, model
+reuse after `empty!`, Boolean, spin, and nonnegative-integer uniform domains,
+fixed variables, maximization, unsupported sets/backends, and a constraint that
+becomes contradictory only after fixed-variable substitution. Small accepted
+models must be compared with brute force and the direct native API.
 
 ## Non-Goals
 
@@ -341,18 +378,23 @@ This design does not:
 - implement functional JuMP constraint support;
 - add a runtime dependency on MathOptSetDistances.jl;
 - stabilize every native constraint type against future SemVer changes;
-- support continuous, spin-domain, or general-integer constrained models;
+- support continuous or infinite-domain models;
+- implement heterogeneous per-variable domains before #67 provides the direct
+  solver contract;
+- make every current native constraint work on every finite domain;
 - define penalty strengths for unsupported constraints;
 - design polynomial objective lowering beyond the shared ingestion boundary;
-  or
+- implement PEPS-specific constraint projections; or
 - add CoTenN's quantum/eigenvalue constraints.
 
 ## Design Acceptance Checklist
 
 A follow-up implementation is complete only when:
 
-- JuMP uses the existing `TenSolver.Optimizer` for constrained binary models;
+- JuMP uses the existing `TenSolver.Optimizer` for constrained finite-domain
+  models supported by the selected backend;
 - the native direct API and MOI front end remain clearly separated;
+- the MOI model store does not assume `ZeroOne`, quadratic objectives, or DMRG;
 - every accepted MOI constraint has a documented native target and projection
   cost;
 - unsupported data fails with a typed, actionable error and no implicit
@@ -360,8 +402,8 @@ A follow-up implementation is complete only when:
 - fixed variables cannot corrupt MOI-variable-to-site mapping;
 - infeasibility is observable through standard MOI status and result
   attributes; and
-- unconstrained QUBODrivers conformance and current direct constraint behavior
-  remain unchanged.
+- Boolean QUBODrivers conformance and current direct constraint behavior remain
+  unchanged.
 
 The projection strategy is inspired by Sharma, Peng, Dangwal, and Achour,
 *“CoTenN: Constrained Optimization with Tensor Networks,”* PLDI 2026. TenSolver

--- a/docs/internal/jump_moi_constraints.md
+++ b/docs/internal/jump_moi_constraints.md
@@ -11,7 +11,7 @@ The central decision is to keep two layers with different responsibilities:
 
 - MOI `function-in-set` constraints are the high-level modeling interface used
   by JuMP.
-- TenSolver's native [`AbstractConstraint`](@ref) subtypes remain the small,
+- TenSolver's native `AbstractConstraint` subtypes remain the small,
   projection-aware intermediate representation (IR) consumed by the solver.
 
 The MOI layer must lower into the native IR. It must not teach the projection
@@ -21,14 +21,14 @@ constraints into penalty terms.
 ## Current Boundary
 
 The direct Julia API already accepts native constraints through the
-`constraints` keyword of [`minimize`](@ref) and [`maximize`](@ref). The DMRG
+`constraints` keyword of `minimize` and `maximize`. The DMRG
 backend lowers each native constraint with `constraint_to_dfa`, constructs its
 projection MPO, and solves in the projected space. The four v1 native types are:
 
-- [`SumConstraint`](@ref);
-- [`NotEqualsConstraint`](@ref);
-- [`ExactlyOneConstraint`](@ref); and
-- [`RelationConstraint`](@ref).
+- `SumConstraint`;
+- `NotEqualsConstraint`;
+- `ExactlyOneConstraint`; and
+- `RelationConstraint`.
 
 The JuMP path stops earlier. `TenSolver.Optimizer` is generated with
 `QUBODrivers.@setup`, and QUBODrivers defines an `AbstractSampler` as an
@@ -156,10 +156,21 @@ Specialized compact patterns are selected before the general sum fallback.
 This is part of correctness for the performance contract, not a cosmetic
 optimization.
 
+A genuine two-sided bound `l <= sum(a[i] * x[i]) <= u` should likewise use one
+specialized projection rather than compose separate lower- and upper-bound
+projectors. A future `SumIntervalConstraint` can use partial-sum states
+`0:u+1`, send every sum above `u` to the overflow state `u+1`, and accept
+states `l:u`. Its projection MPO therefore has bond at most `u + 2`, instead of
+the product of the two one-sided bonds. This compact DFA justifies a native
+type under the public-API rule above. Normalization should still reduce an
+interval with a redundant side to the existing one-sided `SumConstraint`, or
+report static infeasibility when its bounds cannot contain a reachable sum.
+
 ## Initial Mapping Table
 
 All rows below require `ZeroOne` variables. “Bond” is the expected projection
-MPO bond bound after lowering, based on the current native DFA methods.
+MPO bond bound after lowering, based on the current native DFA methods or, for
+the future interval target, the specialized DFA specified above.
 
 | MOI/JuMP form | Native lowering | Bond | Conditions and notes |
 |:--------------|:----------------|:-----|:---------------------|
@@ -167,7 +178,7 @@ MPO bond bound after lowering, based on the current native DFA methods.
 | `sum(x) == length(x) - 1` | `ExactlyOneConstraint(sites, 0)` | 2 | Exactly one selected site is zero. |
 | `x[i] + x[j] <= 1` | `NotEqualsConstraint([i, j], [1, 1])` | 2 | Compact pairwise exclusion. |
 | Nonnegative integer affine function in `EqualTo`, `LessThan`, or `GreaterThan` | `SumConstraint` with `==`, `<=`, or `>=` | `rhs + 2` | Constants are moved into `rhs`; reject invalid normalized data. |
-| Nonnegative integer affine function in `Interval` | Two `SumConstraint`s | Product of the two projection costs | Lower the lower and upper bounds separately; drop a redundant infinite side. |
+| Nonnegative integer affine function in `Interval` | Future `SumIntervalConstraint` | `upper + 2` | Use one two-sided partial-sum DFA; simplify a redundant side to a one-sided `SumConstraint`. |
 | `x[i] - x[j]` in `EqualTo(0)`, `LessThan(0)`, or `GreaterThan(0)` | `RelationConstraint(i, relation, j)` | 2 | Covers equality, implication-style `<=`, and `>=`. |
 | `VectorOfVariables([x[i], x[j]])` in `MOI.AllDifferent(2)` | `RelationConstraint(i, :(!=), j)` | 2 | `AllDifferent` over more than two binary variables is statically infeasible. |
 | `VectorOfVariables(x)` in `MOI.SOS1(weights)` | `SumConstraint(sites, ones, 1; relation = :(<=))` | 3 | `SOS1` means *at most* one nonzero, not exactly one; ordering weights do not change feasibility. |
@@ -300,9 +311,9 @@ remain typed construction or solve errors. Constraint duals are unsupported.
 The implementation should be split into reviewable stages:
 
 1. **Lowering core and typed errors**: add canonical affine normalization,
-   fixed-value substitution, specialized-pattern recognition, a static
-   infeasibility sentinel, and unit tests that compare each native result with
-   the source MOI predicate.
+   fixed-value substitution, specialized-pattern recognition, the compact
+   two-sided sum projector, a static infeasibility sentinel, and unit tests
+   that compare each native result with the source MOI predicate.
 2. **Optimizer storage and copy path**: add the internal MOI/native constraint
    store, the concrete `supports_constraint`, `copy_to`, `empty!`, and query
    methods, and the filtered-model materialization plus composed-index-map

--- a/docs/internal/jump_moi_constraints.md
+++ b/docs/internal/jump_moi_constraints.md
@@ -1,0 +1,358 @@
+# JuMP/MOI Constrained Optimization Architecture
+
+This note defines how a future JuMP/MathOptInterface (MOI) front end should
+lower constrained binary models into TenSolver's native projection-constraint
+pipeline. It is an implementation design, not a description of behavior in the
+current release. In particular, `TenSolver.Optimizer` still accepts
+QUBO models and fixed binary variables, but not the general hard constraints
+described here.
+
+The central decision is to keep two layers with different responsibilities:
+
+- MOI `function-in-set` constraints are the high-level modeling interface used
+  by JuMP.
+- TenSolver's native [`AbstractConstraint`](@ref) subtypes remain the small,
+  projection-aware intermediate representation (IR) consumed by the solver.
+
+The MOI layer must lower into the native IR. It must not teach the projection
+code to dispatch on arbitrary MOI sets, and it must not turn supported hard
+constraints into penalty terms.
+
+## Current Boundary
+
+The direct Julia API already accepts native constraints through the
+`constraints` keyword of [`minimize`](@ref) and [`maximize`](@ref). The DMRG
+backend lowers each native constraint with `constraint_to_dfa`, constructs its
+projection MPO, and solves in the projected space. The four v1 native types are:
+
+- [`SumConstraint`](@ref);
+- [`NotEqualsConstraint`](@ref);
+- [`ExactlyOneConstraint`](@ref); and
+- [`RelationConstraint`](@ref).
+
+The JuMP path stops earlier. `TenSolver.Optimizer` is generated with
+`QUBODrivers.@setup`, and QUBODrivers defines an `AbstractSampler` as an
+unconstrained QUBO/Ising optimizer, apart from variable-domain and fixed-value
+constraints. Its generic `MOI.supports_constraint` fallback rejects other
+constraint types. `QUBODrivers.sample` in TenSolver then extracts only QUBO
+objective data with `QUBOTools.qubo` and calls `minimize` without a
+`constraints` argument. Consequently, JuMP rejects an affine hard constraint
+before `optimize!` reaches TenSolver.
+
+This split is useful: QUBODrivers should continue owning QUBO objective storage,
+sampler attributes, samples, and common MOI result plumbing. TenSolver should
+own the additional hard-constraint store, MOI-to-native normalization, and
+constraint-aware status overrides.
+
+## Public API Decision
+
+`TenSolver.Optimizer` remains the only JuMP optimizer type. A separate
+`ConstrainedOptimizer` would fragment model code and force users to select an
+optimizer based on whether a model happens to contain constraints.
+
+The native constraint constructors remain exported as the low-level direct
+Julia API. They are not a second general-purpose modeling language: the native
+taxonomy stays deliberately small and represents projection strategies with
+known feasibility and cost behavior. JuMP/MOI is the preferred high-level
+modeling surface, while direct users may continue to pass the native types to
+`minimize` and `maximize`.
+
+Both layers therefore remain public, but only the MOI layer should grow
+modeling conveniences and bridges. New native types should be added only when
+they define a useful projection target, normally with a specialized DFA.
+
+## Model-Ingestion Flow
+
+The constrained optimizer should preserve QUBODrivers' non-incremental
+`MOI.copy_to` architecture and specialize it for `TenSolver.Optimizer`:
+
+1. JuMP stores the source model in its normal MOI caching optimizer.
+2. TenSolver's concrete `MOI.copy_to(::Optimizer, src)` inventories domain,
+   fixed-variable, objective, and supported hard-constraint data.
+3. A `MOI.Utilities.ModelFilter` hides only the hard constraints that TenSolver
+   will lower. It must retain `VariableIndex`-in-`ZeroOne`, fixed-variable
+   `VariableIndex`-in-`EqualTo`, the objective, and relevant model and variable
+   attributes.
+4. The filtered view is materialized into a fresh `MOI.Utilities.Model{T}`.
+   This extra copy is required because `ModelFilter` filters query results but
+   does not itself advertise `supports_constraint`; QUBODrivers uses that query
+   to identify the binary domain. TenSolver records the source-to-filtered
+   `MOI.IndexMap`.
+5. The materialized model is passed to the QUBODrivers `AbstractSampler` copy
+   path, which keeps ownership of QUBO construction and fixed-variable
+   objective substitution. TenSolver composes this second index map with the
+   first.
+6. TenSolver substitutes those same fixed values into each hard constraint,
+   simplifies the result, lowers it to native constraints, and maps every
+   remaining source `MOI.VariableIndex` through the composed map to the
+   free-variable site returned by `QUBOTools.index`.
+7. The native constraints are stored in an unexported, typed optimizer
+   attribute. `MOI.empty!` resets that store along with the QUBODrivers model.
+8. `QUBODrivers.sample(::Optimizer)` reads the stored native constraints and
+   passes them to `minimize(...; constraints)`.
+
+This plan uses public MOI filtering and QUBODrivers dispatch rather than calling
+QUBODrivers' private objective-copy helpers. Access to the internal store should
+be isolated behind TenSolver helpers and covered by a QUBODrivers conformance
+test. If the generated optimizer cannot host an unexported typed attribute
+without relying on undocumented fields, the prerequisite is a small
+QUBODrivers extension hook; the fallback is not a global side table keyed by
+optimizer identity.
+
+The optimizer should also retain the original MOI functions and sets needed to
+answer `NumberOfConstraints`, `ListOfConstraintIndices`, `ConstraintFunction`,
+`ConstraintSet`, and `is_valid`. The native constraints are execution data, not
+a substitute for the MOI model's queryable representation. Its returned
+`MOI.IndexMap` must include the separately stored hard-constraint indices as
+well as the objective/domain indices copied by QUBODrivers.
+
+### Fixed variables and static simplification
+
+QUBODrivers can remove fixed variables from the sampled QUBO. Constraint
+lowering must therefore substitute fixed values before assigning native site
+numbers. For example, fixing `x[1] = 1` turns `x[1] + x[2] <= 1` into
+`x[2] <= 0`; referring to the old first site after QUBODrivers removes it would
+constrain the wrong variable.
+
+After substitution, lowering produces one of three results:
+
+- a tautology, which is dropped;
+- one or more native constraints over free sites; or
+- a static contradiction, which marks the solve infeasible without running
+  DMRG.
+
+A static contradiction is a solver outcome, not a model-construction error. It
+must use the same infeasibility status path as an all-zero projection.
+
+## Canonicalization Rules
+
+For a scalar affine function
+
+```math
+f(x) = c + \sum_i a_i x_i,
+```
+
+the lowerer first combines duplicate terms, removes zero coefficients, and
+moves `c` into the set bound. For example,
+`f(x) in MOI.LessThan(u)` becomes `sum(a[i] * x[i]) <= u - c`.
+`MOI.GreaterThan`, `MOI.EqualTo`, and both sides of `MOI.Interval` are handled
+analogously.
+
+The v1 native sum projection accepts nonnegative integer weights and a
+nonnegative integer right-hand side. The MOI bridge must preserve that
+contract:
+
+- coefficients and normalized bounds must be exactly integer-valued; the
+  bridge must not round approximately integral floating-point data;
+- an all-negative expression may be multiplied by `-1`, reversing `<=` and
+  `>=`;
+- mixed-sign expressions are accepted only when they match a specialized
+  pairwise-relation pattern; and
+- strict `<` and `>` constraints are not accepted. A caller that relies on an
+  integer domain must express the equivalent shifted non-strict bound
+  explicitly.
+
+Specialized compact patterns are selected before the general sum fallback.
+This is part of correctness for the performance contract, not a cosmetic
+optimization.
+
+## Initial Mapping Table
+
+All rows below require `ZeroOne` variables. “Bond” is the expected projection
+MPO bond bound after lowering, based on the current native DFA methods.
+
+| MOI/JuMP form | Native lowering | Bond | Conditions and notes |
+|:--------------|:----------------|:-----|:---------------------|
+| `ScalarAffineFunction`-in-`EqualTo(1)`, all unit coefficients | `ExactlyOneConstraint(sites, 1)` | 2 | Prefer this over a general sum. |
+| `sum(x) == length(x) - 1` | `ExactlyOneConstraint(sites, 0)` | 2 | Exactly one selected site is zero. |
+| `x[i] + x[j] <= 1` | `NotEqualsConstraint([i, j], [1, 1])` | 2 | Compact pairwise exclusion. |
+| Nonnegative integer affine function in `EqualTo`, `LessThan`, or `GreaterThan` | `SumConstraint` with `==`, `<=`, or `>=` | `rhs + 2` | Constants are moved into `rhs`; reject invalid normalized data. |
+| Nonnegative integer affine function in `Interval` | Two `SumConstraint`s | Product of the two projection costs | Lower the lower and upper bounds separately; drop a redundant infinite side. |
+| `x[i] - x[j]` in `EqualTo(0)`, `LessThan(0)`, or `GreaterThan(0)` | `RelationConstraint(i, relation, j)` | 2 | Covers equality, implication-style `<=`, and `>=`. |
+| `VectorOfVariables([x[i], x[j]])` in `MOI.AllDifferent(2)` | `RelationConstraint(i, :(!=), j)` | 2 | `AllDifferent` over more than two binary variables is statically infeasible. |
+| `VectorOfVariables(x)` in `MOI.SOS1(weights)` | `SumConstraint(sites, ones, 1; relation = :(<=))` | 3 | `SOS1` means *at most* one nonzero, not exactly one; ordering weights do not change feasibility. |
+| `ScalarAffineFunction` in a TenSolver `NotEqualTo(value)` set | `SumConstraint(...; relation = :(!=))`, or `RelationConstraint` for a pairwise pattern | Native target's bound | MOI has no standard scalar not-equal set. |
+| `VectorOfVariables(x)` in a TenSolver `ForbiddenAssignment(values)` set | `NotEqualsConstraint(sites, values)` | 2 | Compact custom set for excluding one bit pattern. |
+| `VariableIndex` in `EqualTo(0 or 1)` | Existing QUBODrivers fixed-variable path | No projector | Substitute before hard-constraint lowering. |
+
+Exactly-one should normally be modeled as `sum(x) == 1`. Combining that
+equality with `SOS1` is redundant and would create a second projector. A bare
+`SOS1` cannot lower to `ExactlyOneConstraint` because the all-zero assignment
+is feasible for `SOS1`.
+
+The custom `NotEqualTo` and `ForbiddenAssignment` sets belong to the MOI front
+end. They do not replace `SumConstraint` or `NotEqualsConstraint`; they provide
+standard function-in-set syntax for native targets that have no lossless
+off-the-shelf MOI set.
+
+## Point-on-Set Versus Projection MPOs
+
+MOI's function-in-set vocabulary is the right abstraction for declaring the
+feasible set. It should not be confused with the operator that TenSolver builds.
+
+`MOI.Utilities.distance_to_set` and the separate
+[MathOptSetDistances.jl](https://github.com/matbesancon/MathOptSetDistances.jl)
+package operate on numeric points and MOI sets. They can support validation or
+diagnostics, but they do not construct TenSolver's projection MPO. TenSolver's
+`P` is a Hilbert-space operator that is diagonal in the binary computational
+basis, with value one on feasible bitstrings and zero on infeasible bitstrings.
+
+Therefore the first bridge needs no new set-distance dependency. The useful
+connection is conceptual: the MOI set defines membership, the native constraint
+defines a compact automaton for that membership predicate, and the automaton
+defines `P`.
+
+This separation also leaves room for future non-diagonal projections, such as
+the eigenvalue constraints discussed in the CoTenN work, without pretending
+that every projection MPO is a Euclidean point projection.
+
+## Unsupported Constraints and Fallback Policy
+
+The default policy is an explicit hard error. The v1 bridge must not silently:
+
+- convert a hard constraint into a penalty QUBO;
+- enumerate every feasible assignment through the legacy generic projection
+  path; or
+- accept a bridge that introduces continuous, general-integer, or otherwise
+  non-binary auxiliary variables.
+
+Penalty conversion changes the optimization problem unless a safe penalty
+scale is known. Generic feasible-path enumeration preserves semantics but can
+have exponentially larger bonds and is slated for removal in favor of explicit
+automata. Neither is an acceptable implicit fallback.
+
+For unsupported function/set *types*, `MOI.supports_constraint` returns false,
+allowing MOI to try a registered bridge and otherwise raise
+`MOI.UnsupportedConstraint`. For a supported type with unsupported data, such
+as mixed-sign general affine coefficients, TenSolver raises
+`MOI.AddConstraintNotAllowed{F,S}` with the exact violated restriction and a
+suggested supported formulation.
+
+The native layer should gain catchable `InvalidConstraintError` and
+`ConstraintUnsupportedByBackend` errors in the implementation epic. The MOI
+adapter translates validation failures during model copy into MOI's typed
+construction errors. Backend incompatibility remains a typed solve-time error;
+infeasibility never uses either exception.
+
+If an opt-in penalty or generic-exact fallback is added later, it requires a
+separate public optimizer attribute, explicit cost warnings, and tests proving
+that the default remains hard-error behavior.
+
+## Bridge Policy
+
+TenSolver should advertise direct support for each row in the mapping table so
+MOI does not replace a compact pattern with a generic MILP bridge. Other MOI
+bridges may be used only when their output consists entirely of supported
+binary functions and sets. Every introduced variable must have a `ZeroOne`
+domain before the model reaches native lowering.
+
+Bridge output is canonicalized exactly like user-authored constraints. The
+bridge boundary cannot bypass integer, nonnegativity, fixed-variable, or
+backend checks.
+
+The projection layer remains MOI-agnostic. No method in `projection_mpo.jl`
+should accept an MOI function or set.
+
+## Result and Status Contract
+
+The native status behavior is already defined:
+
+- infeasible `minimize` returns `(+Inf, infeasible_solution)`;
+- infeasible `maximize` returns `(-Inf, infeasible_solution)`;
+- `is_feasible(solution)` is false; and
+- sampling an infeasible solution throws.
+
+The MOI layer maps that outcome to:
+
+- `MOI.TerminationStatus() == MOI.INFEASIBLE`;
+- `MOI.ResultCount() == 0`;
+- `MOI.PrimalStatus() == MOI.NO_SOLUTION`; and
+- an empty QUBOTools `SampleSet` with the TenSolver status in metadata.
+
+TenSolver already computes `MOI.INFEASIBLE` in `tensolver_status`, but the
+generic QUBODrivers termination-status getter treats a nonempty metadata object
+with zero samples as `MOI.OTHER_ERROR`. The constrained implementation must add
+a concrete `MOI.get(::Optimizer, ::MOI.TerminationStatus)` override that reads
+TenSolver's recorded status. Metadata alone does not complete the MOI contract.
+
+Invalid model data and unsupported backends do not map to `INFEASIBLE`: they
+remain typed construction or solve errors. Constraint duals are unsupported.
+
+## Coordination With Related Work
+
+- #37 and #62 are complete. The bridge targets the landed backend-aware
+  `minimize`/`maximize` path and native `constraints` keyword.
+- #64 is complete. Its public constraints page defines the native vocabulary
+  and measured projection costs used by this design.
+- #68 should reuse the same MOI ingestion layer for polynomial objectives. A
+  future objective adapter may accept PolyJuMP data or a polynomial subset of
+  `MOI.ScalarNonlinearFunction`, but it must not create a second optimizer or a
+  separate model cache.
+- #95 is a future native `SumModConstraint`. Because MOI has no standard scalar
+  modulo-equality set, it should add a custom MOI set that lowers to that native
+  type, following the same extension pattern as `NotEqualTo` and
+  `ForbiddenAssignment`.
+- #55 remains the coordination epic. This design completes its JuMP/MOI design
+  child but does not implement the bridge.
+
+## Follow-Up Implementation Epic
+
+The implementation should be split into reviewable stages:
+
+1. **Lowering core and typed errors**: add canonical affine normalization,
+   fixed-value substitution, specialized-pattern recognition, a static
+   infeasibility sentinel, and unit tests that compare each native result with
+   the source MOI predicate.
+2. **Optimizer storage and copy path**: add the internal MOI/native constraint
+   store, the concrete `supports_constraint`, `copy_to`, `empty!`, and query
+   methods, and the filtered-model materialization plus composed-index-map
+   handoff to QUBODrivers.
+3. **Standard and custom sets**: implement the supported standard mapping rows,
+   then add `NotEqualTo` and `ForbiddenAssignment` with JuMP syntax and MOI
+   conformance tests.
+4. **Solve and status integration**: pass native constraints through
+   `QUBODrivers.sample`, add concrete status getters, and verify empty-result
+   infeasibility behavior.
+5. **End-to-end documentation and tests**: add JuMP examples for weighted sums,
+   exactly-one, pairwise exclusion/relation, infeasibility, fixed variables,
+   and every rejection path. Compare small solutions against brute force and
+   the direct native API.
+
+Each stage must preserve unconstrained QUBODrivers behavior. The test matrix
+should include direct MOI use, JuMP's caching/bridge optimizer, model reuse after
+`empty!`, fixed variables, maximization, unsupported sets, and a constraint that
+becomes contradictory only after fixed-variable substitution.
+
+## Non-Goals
+
+This design does not:
+
+- implement functional JuMP constraint support;
+- add a runtime dependency on MathOptSetDistances.jl;
+- stabilize every native constraint type against future SemVer changes;
+- support continuous, spin-domain, or general-integer constrained models;
+- define penalty strengths for unsupported constraints;
+- design polynomial objective lowering beyond the shared ingestion boundary;
+  or
+- add CoTenN's quantum/eigenvalue constraints.
+
+## Design Acceptance Checklist
+
+A follow-up implementation is complete only when:
+
+- JuMP uses the existing `TenSolver.Optimizer` for constrained binary models;
+- the native direct API and MOI front end remain clearly separated;
+- every accepted MOI constraint has a documented native target and projection
+  cost;
+- unsupported data fails with a typed, actionable error and no implicit
+  penalty or exponential fallback;
+- fixed variables cannot corrupt MOI-variable-to-site mapping;
+- infeasibility is observable through standard MOI status and result
+  attributes; and
+- unconstrained QUBODrivers conformance and current direct constraint behavior
+  remain unchanged.
+
+The projection strategy is inspired by Sharma, Peng, Dangwal, and Achour,
+*“CoTenN: Constrained Optimization with Tensor Networks,”* PLDI 2026. TenSolver
+uses that projection-MPO framework as the motivation for keeping the native IR
+small and cost-aware.


### PR DESCRIPTION
## Summary

- add an internal architecture document for lowering JuMP/MOI function-in-set constraints into TenSolver's native projection-constraint IR
- keep `TenSolver.Optimizer` as the single JuMP entry point, backed by a TenSolver-owned full MOI model store rather than a Boolean-QUBO-only copy path
- define finite-domain normalization, backend/objective handoff, supported constraint mappings, projection costs, fixed-variable handling, typed errors, and infeasibility results
- retain QUBODrivers as the compatibility adapter for existing Boolean quadratic models, attributes, samples, and result behavior
- index the design note from the repository documentation guide

This PR is design-only. It does not add functional JuMP constraint support or new dependencies.

## Key decisions

- MOI sets are the user-facing modeling abstraction; `AbstractConstraint` subtypes remain the compact, projection-aware lowering targets.
- The MOI store makes no blanket `ZeroOne`, quadratic-objective, or DMRG assumption. The first backend adapter targets DMRG's current uniform finite-domain contract and leaves heterogeneous domains to #67.
- TenSolver owns domains, objective/constraint normalization, backend selection, and status mapping. QUBODrivers remains a narrow Boolean-QUBO compatibility adapter; generally useful hooks may be contributed upstream without moving TenSolver-specific semantics there.
- Two-sided weighted sums extend `SumConstraint` with an interval relation and one capped DFA instead of introducing a redundant constraint type.
- Domain-specific compact patterns are selected only after domain normalization. The mapping table covers nonnegative-integer sums and domain-independent relation, all-different, exactly-one-value, and forbidden-assignment targets.
- #44 backend selection and #68 polynomial objectives reuse the same stored MOI model and normalization boundary.
- Unsupported constraints fail explicitly. There is no implicit penalty-QUBO or exhaustive feasible-assignment fallback.
- MOI infeasibility surfaces as `MOI.INFEASIBLE` with zero results and no primal values.

## Coordination

- Closes #65.
- Parent epic: #55.
- The design targets the landed work from #37, #62, #64, #97, #105, #106, and #109.
- #44 supplies the pending optional-backend integration; backend capabilities remain explicit.
- #67 owns future heterogeneous per-variable domains.
- #68 should reuse this MOI store for polynomial objectives.
- #95 should follow the documented custom-set extension pattern when its native modulo constraint exists.

## Validation

- `julia +release --startup-file=no -e 'using Markdown; for file in ARGS; Markdown.parse(read(file, String)); println("parsed ", file); end' docs/internal/jump_moi_constraints.md docs/DOCUMENTATION.md`
- `julia +release --project=docs/ docs/make.jl local`
- `julia +release --project=. -e 'using Pkg; Pkg.test()'`
- `git diff --check`

All checks pass locally with Julia 1.12.0.

## Branch Hygiene

- Base refreshed through `main` at `2a7a6000e02e75923280f68b30bd7debcb5a85d7` with append-only merge commit `6ddd51f`.
- Head: `pr-10-jump-moi-design` at `988bef5ee04e97fd9a9c7620dd47c93ca5096aac`.
- Not stacked; prerequisite PR #101 for #64 is merged.
- Open PR #46 also edits `docs/DOCUMENTATION.md` in the adjacent internal-note inventory. The changes are semantically disjoint, but this branch should be refreshed again if #46 lands first.
