### PR TITLE
Add Spin-domain optimization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $$\begin{array}{rl}
   \text{s.t.} & Ax = b \\
               & P x \le q \\
               & x \text{ satisfies other constraints} \\
-              & x \in \{0,\ldots,d-1\}^{n}
+              & x \in \{0,\ldots,d-1\}^{n} \text{ or } x \in \{-1,+1\}^{n}
 \end{array}$$
 
 Additionally, TenSolver provides special support
@@ -51,6 +51,21 @@ These vectors are the (approximate) optimal solutions to the original optimizati
 ```julia
 x = TenSolver.sample(psi)
 ```
+
+### Ising models
+
+Pass the Spin domain to optimize an Ising objective directly:
+
+```julia
+J = [0.0 -1.0; -1.0 0.0]
+h = [0.25, -0.5]
+
+E, psi = TenSolver.minimize(J, h; domain = [-1, 1])
+s = TenSolver.sample(psi)  # every entry is -1 or +1
+```
+
+Boolean optimization remains the default (`domain = [0, 1]`). The existing
+`domain_dim = d` keyword continues to select the integer domain `0:(d - 1)`.
 
 ### Constraints
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $$\begin{array}{rl}
   \text{s.t.} & Ax = b \\
               & P x \le q \\
               & x \text{ satisfies other constraints} \\
-              & x \in \{0,\ldots,d-1\}^{n} \text{ or } x \in \{-1,+1\}^{n}
+              & x \in \{0,\ldots,d-1\}^{n}
 \end{array}$$
 
 Additionally, TenSolver provides special support
@@ -51,21 +51,6 @@ These vectors are the (approximate) optimal solutions to the original optimizati
 ```julia
 x = TenSolver.sample(psi)
 ```
-
-### Ising models
-
-Pass the Spin domain to optimize an Ising objective directly:
-
-```julia
-J = [0.0 -1.0; -1.0 0.0]
-h = [0.25, -0.5]
-
-E, psi = TenSolver.minimize(J, h; domain = [-1, 1])
-s = TenSolver.sample(psi)  # every entry is -1 or +1
-```
-
-Boolean optimization remains the default (`domain = [0, 1]`). The existing
-`domain_dim = d` keyword continues to select the integer domain `0:(d - 1)`.
 
 ### Constraints
 

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -41,7 +41,7 @@ keep constrained solves close to the unconstrained cost.
 
 | Constraint | Enforces | Bond dimension of ``P`` |
 |:-----------|:---------|:------------------------|
-| [`SumConstraint`](@ref) | ``\sum_i w_i \, x_{s_i} \lessgtr b`` | ``b + 2`` for nonnegative domains; number of reachable partial sums for signed domains |
+| [`SumConstraint`](@ref) | ``\sum_i w_i \, x_{s_i} \lessgtr b`` | ``b + 2`` (independent of the number of variables) |
 | [`NotEqualsConstraint`](@ref) | ``x_S \ne v`` (one forbidden assignment) | 2 |
 | [`ExactlyOneConstraint`](@ref) | ``\mathrm{count}_{i \in S}(x_i = k) = 1`` | 2 |
 | [`RelationConstraint`](@ref) | ``x_i \lessgtr x_j`` | 2 |
@@ -67,7 +67,7 @@ x = TenSolver.sample(psi)
 
 # output
 
-(true, [1, 0, 1], true)
+(true, [1.0, 0.0, 1.0], true)
 ```
 
 You can also check an assignment against constraints directly with
@@ -94,10 +94,9 @@ You can also check an assignment against constraints directly with
 ```
 
 where `relation` is one of `:(==)`, `:(!=)`, `:(<=)`, or `:(>=)`. The `sites` are unique positive integers representing variable indices, while `weights` and
-`rhs` must be **nonnegative integers**. For nonnegative domains, its automaton
-tracks the capped partial sum, so the projection bond dimension is `rhs + 2`
-regardless of how many variables the sum touches. For signed domains such as
-`[-1, 1]`, it instead tracks every reachable partial sum exactly.
+`rhs` must be **nonnegative integers**. Its automaton tracks the capped partial
+sum, so the projection bond dimension is `rhs + 2` regardless of how many
+variables the sum touches.
 
 ### NotEqualsConstraint
 
@@ -119,7 +118,7 @@ E, psi = TenSolver.minimize(zeros(2, 2), [-2.0, -1.0]; constraints = [exclude], 
 
 # output
 
-(true, [1, 0])
+(true, [1.0, 0.0])
 ```
 
 ### ExactlyOneConstraint
@@ -145,7 +144,7 @@ E, psi = TenSolver.minimize(zeros(3, 3), [-1.0, -3.0, -2.0]; constraints = [one_
 
 # output
 
-(true, [0, 1, 0])
+(true, [0.0, 1.0, 0.0])
 ```
 
 ### RelationConstraint
@@ -167,7 +166,7 @@ E, psi = TenSolver.minimize(zeros(2, 2), [-2.0, 1.0]; constraints = [implies], v
 
 # output
 
-(true, [1, 1])
+(true, [1.0, 1.0])
 ```
 
 ## Combining constraints
@@ -192,7 +191,7 @@ x = TenSolver.sample(psi)
 
 # output
 
-(true, [1, 0, 1], true)
+(true, [1.0, 0.0, 1.0], true)
 ```
 
 ## Infeasible models

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -41,7 +41,7 @@ keep constrained solves close to the unconstrained cost.
 
 | Constraint | Enforces | Bond dimension of ``P`` |
 |:-----------|:---------|:------------------------|
-| [`SumConstraint`](@ref) | ``\sum_i w_i \, x_{s_i} \lessgtr b`` | ``b + 2`` (independent of the number of variables) |
+| [`SumConstraint`](@ref) | ``\sum_i w_i \, x_{s_i} \lessgtr b`` | ``b + 2`` for nonnegative domains; number of reachable partial sums for signed domains |
 | [`NotEqualsConstraint`](@ref) | ``x_S \ne v`` (one forbidden assignment) | 2 |
 | [`ExactlyOneConstraint`](@ref) | ``\mathrm{count}_{i \in S}(x_i = k) = 1`` | 2 |
 | [`RelationConstraint`](@ref) | ``x_i \lessgtr x_j`` | 2 |
@@ -94,9 +94,10 @@ You can also check an assignment against constraints directly with
 ```
 
 where `relation` is one of `:(==)`, `:(!=)`, `:(<=)`, or `:(>=)`. The `sites` are unique positive integers representing variable indices, while `weights` and
-`rhs` must be **nonnegative integers**. Its automaton tracks the capped partial
-sum, so the projection bond dimension is `rhs + 2` regardless of how many
-variables the sum touches.
+`rhs` must be **nonnegative integers**. For nonnegative domains, its automaton
+tracks the capped partial sum, so the projection bond dimension is `rhs + 2`
+regardless of how many variables the sum touches. For signed domains such as
+`[-1, 1]`, it instead tracks every reachable partial sum exactly.
 
 ### NotEqualsConstraint
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -30,6 +30,30 @@ x = TenSolver.sample(psi)
 (true, "Wind, Battery")
 ```
 
+## Ising Model
+
+Use `domain = [-1, 1]` when the variables are Ising spins:
+
+```jldoctest ising-domain
+using TenSolver
+
+J = [0.0 -1.0;
+     -1.0 0.0]
+h = [0.25, -0.5]
+
+E, psi = TenSolver.minimize(J, h; domain = [-1, 1], verbosity = 0)
+s = TenSolver.sample(psi)
+
+(E ≈ -2.25, s, all(in((-1, 1)), s))
+
+# output
+
+(true, [1, 1], true)
+```
+
+Boolean variables remain the default. The legacy `domain_dim = d` keyword
+continues to select the nonnegative integer domain `0:(d - 1)`.
+
 ## QUBO with Linear and Constant Terms
 
 You can also specify linear and constant terms:

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -48,11 +48,10 @@ s = TenSolver.sample(psi)
 
 # output
 
-(true, [1, 1], true)
+(true, [1.0, 1.0], true)
 ```
 
-Boolean variables remain the default. The legacy `domain_dim = d` keyword
-continues to select the nonnegative integer domain `0:(d - 1)`.
+Boolean variables remain the default.
 
 ## QUBO with Linear and Constant Terms
 

--- a/src/TenSolver.jl
+++ b/src/TenSolver.jl
@@ -104,7 +104,7 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
   reads = is_feasible(psi) ? final_num_reads : 0
   samples = Vector{QUBOTools.Sample{T,Int}}(undef, reads)
   for i in 1:reads
-    x = sample(psi)
+    x = Int.(sample(psi))
     E = QUBOTools.value(x, l, Q, a, b)
 
     samples[i] = QUBOTools.Sample{T,Int}(x, E)

--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -86,7 +86,7 @@ Backend-specific keyword arguments:
 function minimize(::DMRGBackend, Q::AbstractMatrix{T}, l::AbstractVector{T}, c::T
   ; cutoff=1e-8
   , preprocess::Bool=false
-  , domain = 0:1
+  , domain::AbstractVector = 0:1
   , kwargs...
 ) where T
   domain_values = validate_solve_domain(domain)
@@ -112,7 +112,7 @@ function minimize(
   p::AbstractPolynomial{T}
   ;
   cutoff=1e-8,
-  domain = 0:1,
+  domain::AbstractVector = 0:1,
   kwargs...,
 ) where T
   domain_values = validate_solve_domain(domain)

--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -6,6 +6,7 @@ import ITensors, ITensorMPS
 import MultivariatePolynomials: AbstractPolynomial, coefficient, monomial, terms, variables, effective_variables, powers, isconstant
 
 # Diagonal matrix whose eigenvalues are the ordered feasible values for a variable.
+# For Spin variables, this is the Pauli σ_z matrix.
 # For Boolean variables, this is a projection on |1>. Or equivalently, (I - σ_z) / 2.
 # This looks like type piracy,
 # but is, in fact, ITensors' way to extend the OpSum mechanism.
@@ -33,23 +34,25 @@ struct DMRGBackend <: AbstractTenSolverBackend end
 normalize_backend(::Val{:dmrg}) = default_backend
 
 function validate_solve_domain(domain)
-  applicable(iterate, domain) || throw(ArgumentError("`domain` must be an iterable collection of values"))
-  applicable(length, domain) || throw(ArgumentError("`domain` must have a finite length"))
-  isempty(domain) && throw(ArgumentError("`domain` must contain at least one value"))
-  all(value -> value isa Real, domain) || throw(ArgumentError("`domain` values must be real numbers"))
-  allunique(domain) || throw(ArgumentError("`domain` values must be unique"))
+  # Preprocessing to dedeplicate domain values
+  domain = (ismutable(domain) ? unique! : unique)(sort(domain))
+  d = length(domain)
 
-  nonnegative_integer = all(
-    value == expected
-    for (value, expected) in zip(domain, 0:(length(domain) - 1))
-  )
-  spin = length(domain) == 2 && all(value -> abs(value) == 1, domain)
-  if !(nonnegative_integer || spin)
-    throw(ArgumentError("unsupported domain $(repr(domain)); use `0:(d - 1)` or a permutation of `[-1, 1]`"))
+  if !applicable(iterate, domain)
+    throw(ArgumentError("`domain` must be an iterable collection of values"))
+  elseif !applicable(length, domain)
+    throw(ArgumentError("`domain` must have a finite length"))
+  elseif isempty(domain)
+    throw(ArgumentError("`domain` must contain at least one value"))
+  elseif !all(value -> value isa Real, domain)
+    throw(ArgumentError("`domain` values must be real numbers"))
+  elseif !allunique(domain)
+    throw(ArgumentError("`domain` values must be unique"))
+  elseif !(domain == 0:(d-1) || domain == [-1, 1])
+    throw(ArgumentError("Unsupported domain $(repr(domain)); use `0:(d - 1)` or `[-1, 1]`"))
   end
 
-  # `diagm` accepts vectors (including ranges), but not every finite iterable.
-  return domain isa AbstractVector ? domain : collect(domain)
+  return domain
 end
 
 """
@@ -66,14 +69,6 @@ where D_i is diagonal with the variable's domain values. By default,
 
 Backend-specific keyword arguments:
 
-- `constraints :: AbstractVector{<:AbstractConstraint}` - Experimental native Julia hard constraints.
-  Defaults to `AbstractConstraint[]`. In constrained DMRG solves, TenSolver lowers each constraint to
-  a projection MPO, solves the projected Hamiltonian, and returns a feasible sampled assignment.
-  For polynomial objectives, constraints are expressed in the same order as their `effective_variables`.
-  If the constraints admit no solution at all, the solve does not error: it logs a warning and
-  returns `+Inf` together with an infeasible [`Solution`](@ref) (see [`is_feasible`](@ref)).
-- `domain` - Ordered variable values. Defaults to `0:1`; use `[-1, 1]` for
-  Ising spins or `0:(d - 1)` for a nonnegative integer domain of size `d`.
 - `maxdim` - The maximum allowed bond dimension.
   Integer or array of integer specifying the bond dimension per iteration.
   You can use this keyword to control the solver's accuracy vs resources trade-off.
@@ -203,8 +198,7 @@ function tensorize(
   end
 
   N = size(Q, 1)
-  dim = length(domain)
-  sites = ITensors.siteinds("Qudit", N; dim = dim)
+  sites = ITensors.siteinds("Qudit", N; dim = length(domain))
   os = OpSum{T}()
 
   for t in Qs
@@ -230,8 +224,7 @@ function tensorize(
   domain,
 ) where T
   N = length(effective_variables(p))
-  dim = length(domain)
-  sites = ITensors.siteinds("Qudit", N; dim = dim)
+  sites = ITensors.siteinds("Qudit", N; dim = length(domain))
   os = OpSum{T}()
 
   # Map: var name => index
@@ -388,7 +381,7 @@ function minimize_mpo( H :: MPO
   else
     # The calculated energy has approximation errors compared to the true solution.
     # It makes more sense to sample a solution and calculate the true objective function applied to it.
-    dist = Solution{T}(psi, energies_log, bond_dims_log, elapsed_times_log, permutation, domain)
+    dist = Solution{T}(psi, domain, permutation, energies_log, bond_dims_log, elapsed_times_log)
     optimal = obj(sample(dist))
   end
 

--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -5,11 +5,15 @@ import ITensors, ITensorMPS
 
 import MultivariatePolynomials: AbstractPolynomial, coefficient, monomial, terms, variables, effective_variables, powers, isconstant
 
-# Diagonal matrix whose eigenvalues are the ordered feasible values for an integer variable.
-# For qubits, this is a projection on |1>. Or equivalently, (I - σ_z) / 2.
+# Diagonal matrix whose eigenvalues are the ordered feasible values for a variable.
+# For Boolean variables, this is a projection on |1>. Or equivalently, (I - σ_z) / 2.
 # This looks like type piracy,
 # but is, in fact, ITensors' way to extend the OpSum mechanism.
-ITensors.op(::OpName"D",::SiteType"Qudit", d::Int) = diagm(0:(d-1))
+function ITensors.op(::OpName"D", ::SiteType"Qudit", d::Int; domain=0:(d - 1))
+  values = collect(domain)
+  length(values) == d || throw(DimensionMismatch("operator domain length must match the site dimension"))
+  return diagm(values)
+end
 
 function ITensors.state(::StateName"full", ::SiteType"Qudit", s::ITensorMPS.Index)
   d = ITensorMPS.dim(s)
@@ -30,25 +34,48 @@ struct DMRGBackend <: AbstractTenSolverBackend end
 
 normalize_backend(::Val{:dmrg}) = default_backend
 
+function normalize_solve_domain(domain, domain_dim)
+  if !isnothing(domain) && !isnothing(domain_dim)
+    throw(ArgumentError("`domain` and `domain_dim` cannot be specified together"))
+  end
+
+  if isnothing(domain)
+    dim = isnothing(domain_dim) ? 2 : domain_dim
+    dim > 0 || throw(ArgumentError("`domain_dim` must be positive, got $dim"))
+    return collect(0:(dim - 1))
+  end
+
+  applicable(iterate, domain) || throw(ArgumentError("`domain` must be an iterable collection of values"))
+  values = collect(domain)
+  values == [0, 1] && return [0, 1]
+  values == [-1, 1] && return [-1, 1]
+
+  throw(ArgumentError("unsupported domain $(repr(values)); supported domains are [0, 1] and [-1, 1]"))
+end
+
 """
-    minimize(::DRMGBackend, Q::Matrix[, l::Vector[, c::Number ; kwargs...)
+    minimize(::DMRGBackend, Q::Matrix[, l::Vector[, c::Number ; kwargs...)
 
 This function uses DMRG with tensor networks to calculate the optimal solution,
 by finding the ground state (least eigenspace) of the Hamiltonian
 
     H = Σ Q_ij D_iD_j + Σ l_i D_i
 
-where D_i acts locally on the i-th qubit as [0 0; 0 1], i.e, the projection on |1>.
+where D_i is diagonal with the variable's domain values. By default,
+`domain = [0, 1]`; pass `domain = [-1, 1]` to optimize an Ising model directly.
 
 
 Backend-specific keyword arguments:
 
 - `constraints :: AbstractVector{<:AbstractConstraint}` - Experimental native Julia hard constraints.
   Defaults to `AbstractConstraint[]`. In constrained DMRG solves, TenSolver lowers each constraint to
-  a projection MPO, solves the projected Hamiltonian, and returns a feasible sampled bitstring.
+  a projection MPO, solves the projected Hamiltonian, and returns a feasible sampled assignment.
   For polynomial objectives, constraints are expressed in the same order as their `effective_variables`.
   If the constraints admit no solution at all, the solve does not error: it logs a warning and
   returns `+Inf` together with an infeasible [`Solution`](@ref) (see [`is_feasible`](@ref)).
+- `domain` - The variable domain. Supported values are `[0, 1]` (the default)
+  and `[-1, 1]` for Ising spins. `domain_dim` remains available for the legacy
+  nonnegative integer domain `0:(domain_dim - 1)`; do not pass both keywords.
 - `maxdim` - The maximum allowed bond dimension.
   Integer or array of integer specifying the bond dimension per iteration.
   You can use this keyword to control the solver's accuracy vs resources trade-off.
@@ -66,14 +93,16 @@ Backend-specific keyword arguments:
 function minimize(::DMRGBackend, Q::AbstractMatrix{T}, l::AbstractVector{T}, c::T
   ; cutoff=1e-8
   , preprocess::Bool=false
-  , domain_dim::Integer = 2
+  , domain = nothing
+  , domain_dim::Union{Nothing,Integer} = nothing
   , kwargs...
 ) where T
+  domain_values = normalize_solve_domain(domain, domain_dim)
   Qp, lp, permutation = preprocess ? preprocess_qubo(Q, l, cutoff) : (Q, l, collect(1:size(Q, 1)))
-  H      = tensorize(Qp, lp; cutoff, dim = domain_dim)
+  H      = tensorize(Qp, lp; cutoff, dim = length(domain_values), domain = domain_values)
   obj(x) = dot(x, Q, x) + dot(l, x) + c
 
-  return minimize_mpo(H, c, obj ; cutoff, permutation, domain_dim, kwargs...)
+  return minimize_mpo(H, c, obj ; cutoff, permutation, domain = domain_values, kwargs...)
 end
 
 """
@@ -91,15 +120,17 @@ function minimize(
   p::AbstractPolynomial{T}
   ;
   cutoff=1e-8,
-  domain_dim::Integer = 2,
+  domain = nothing,
+  domain_dim::Union{Nothing,Integer} = nothing,
   kwargs...,
 ) where T
-  H      = tensorize(p; cutoff, dim = domain_dim)
+  domain_values = normalize_solve_domain(domain, domain_dim)
+  H      = tensorize(p; cutoff, dim = length(domain_values), domain = domain_values)
   cte    = constant_term(p)
   vs     = effective_variables(p)
   obj(x) = real(p(vs => x))
 
-  return minimize_mpo(H, cte, obj ; cutoff, domain_dim, kwargs...)
+  return minimize_mpo(H, cte, obj ; cutoff, domain = domain_values, kwargs...)
 end
 
 
@@ -145,10 +176,10 @@ end
 # Infeasibility is a solver outcome, not an argument error: report it as a
 # status like other optimization packages (objective +Inf, empty Solution),
 # so it maps onto MOI.INFEASIBLE at the JuMP layer. See the discussion in #94.
-function infeasible_result(::Type{T}) where {T}
+function infeasible_result(::Type{T}, domain) where {T}
   @warn "constraints define an empty feasible subspace"
   F = float(T)
-  return real(T)(+Inf), infeasible_solution(F)
+  return real(T)(+Inf), infeasible_solution(F, domain)
 end
 
 
@@ -164,13 +195,21 @@ for a matrix `P_i` whose eigenvalues represent its feasible set `K_i`.
 """
 function tensorize end
 
-function tensorize(Q::AbstractArray{T}, rest::Vararg{AbstractArray{T}}; cutoff = zero(T), dim::Integer) where T
+function tensorize(
+  Q::AbstractArray{T},
+  rest::Vararg{AbstractArray{T}};
+  cutoff = zero(T),
+  dim::Integer,
+  domain = 0:(dim - 1),
+) where T
   Qs = [Q, rest...]
   if !allequal(Iterators.flatmap(size, Qs))
     throw(DimensionMismatch("All arrays should act on the same number of variables.\nEncountered dimensions $(collect(map(size, Qs)))."))
   end
 
   N = size(Q, 1)
+  domain_values = collect(domain)
+  length(domain_values) == dim || throw(DimensionMismatch("domain length must match `dim`"))
   sites = ITensors.siteinds("Qudit", N; dim = dim)
   os = OpSum{T}()
 
@@ -182,7 +221,7 @@ function tensorize(Q::AbstractArray{T}, rest::Vararg{AbstractArray{T}}; cutoff =
       coeff = sum(k -> t[k...], multiset_permutations(idx, ndims(t)))
 
       if abs(coeff) > cutoff
-        op   = Iterators.flatmap(v -> ("D", v), idx)
+        op   = Iterators.flatmap(v -> ("D", (domain = domain_values,), v), idx)
         os .+= (coeff, op...)
       end
     end
@@ -191,8 +230,15 @@ function tensorize(Q::AbstractArray{T}, rest::Vararg{AbstractArray{T}}; cutoff =
   return isempty(os) ? MPO(T,sites) : MPO(T, os, sites)
 end
 
-function tensorize(p::AbstractPolynomial{T}; cutoff = zero(T), dim::Integer) where T
+function tensorize(
+  p::AbstractPolynomial{T};
+  cutoff = zero(T),
+  dim::Integer,
+  domain = 0:(dim - 1),
+) where T
   N = length(effective_variables(p))
+  domain_values = collect(domain)
+  length(domain_values) == dim || throw(DimensionMismatch("domain length must match `dim`"))
   sites = ITensors.siteinds("Qudit", N; dim = dim)
   os = OpSum{T}()
 
@@ -206,7 +252,9 @@ function tensorize(p::AbstractPolynomial{T}; cutoff = zero(T), dim::Integer) whe
       op = Iterators.flatten(
         map(powers(t)) do p
           v, e = p
-          Iterators.flatten(Iterators.repeated(("D", indices[v]), e))
+          Iterators.flatten(
+            Iterators.repeated(("D", (domain = domain_values,), indices[v]), e),
+          )
         end
       )
       os .+= (coeff, op...)
@@ -223,7 +271,7 @@ function minimize_mpo( H :: MPO
                      , cutoff      = 1e-8  #  a cutoff of 1E-5 gives sensible accuracy; a cutoff of 1E-8 is high accuracy; and a cutoff of 1E-12 is near exact accuracy. (https://itensor.org/docs.cgi?page=tutorials/dmrg_params)
                      , verbosity   = 1
                      , constraints = AbstractConstraint[]
-                     , domain_dim :: Integer
+                     , domain :: AbstractVector
                      # Stopping criteria
                      , iterations :: Union{Nothing, Int} = nothing
                      , time_limit = +Inf
@@ -254,7 +302,7 @@ function minimize_mpo( H :: MPO
   # Constraints
   projections = map(
     device,
-    projection_mpos(T, constraints, sites; permutation),
+    projection_mpos(T, constraints, sites; permutation, domain),
   )
 
   # Hamiltonian construction
@@ -264,7 +312,7 @@ function minimize_mpo( H :: MPO
   # Initial state
   psi = constrained_initial_state(T, sites, projections; cutoff, inidim)
   if isnothing(psi)
-    return infeasible_result(T)
+    return infeasible_result(T, domain)
   end
   psi = device(psi)
 
@@ -344,11 +392,11 @@ function minimize_mpo( H :: MPO
 
 
   if isinf(energy)
-    optimal, dist = infeasible_result(T)
+    optimal, dist = infeasible_result(T, domain)
   else
     # The calculated energy has approximation errors compared to the true solution.
     # It makes more sense to sample a solution and calculate the true objective function applied to it.
-    dist = Solution{T}(psi, energies_log, bond_dims_log, elapsed_times_log, permutation)
+    dist = Solution{T}(psi, energies_log, bond_dims_log, elapsed_times_log, permutation, domain)
     optimal = obj(sample(dist))
   end
 

--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -9,10 +9,8 @@ import MultivariatePolynomials: AbstractPolynomial, coefficient, monomial, terms
 # For Boolean variables, this is a projection on |1>. Or equivalently, (I - σ_z) / 2.
 # This looks like type piracy,
 # but is, in fact, ITensors' way to extend the OpSum mechanism.
-function ITensors.op(::OpName"D", ::SiteType"Qudit", d::Int; domain=0:(d - 1))
-  values = collect(domain)
-  length(values) == d || throw(DimensionMismatch("operator domain length must match the site dimension"))
-  return diagm(values)
+function ITensors.op(::OpName"D", ::SiteType"Qudit", ::Int; domain)
+  return diagm(domain)
 end
 
 function ITensors.state(::StateName"full", ::SiteType"Qudit", s::ITensorMPS.Index)
@@ -34,23 +32,24 @@ struct DMRGBackend <: AbstractTenSolverBackend end
 
 normalize_backend(::Val{:dmrg}) = default_backend
 
-function normalize_solve_domain(domain, domain_dim)
-  if !isnothing(domain) && !isnothing(domain_dim)
-    throw(ArgumentError("`domain` and `domain_dim` cannot be specified together"))
-  end
-
-  if isnothing(domain)
-    dim = isnothing(domain_dim) ? 2 : domain_dim
-    dim > 0 || throw(ArgumentError("`domain_dim` must be positive, got $dim"))
-    return collect(0:(dim - 1))
-  end
-
+function validate_solve_domain(domain)
   applicable(iterate, domain) || throw(ArgumentError("`domain` must be an iterable collection of values"))
-  values = collect(domain)
-  values == [0, 1] && return [0, 1]
-  values == [-1, 1] && return [-1, 1]
+  applicable(length, domain) || throw(ArgumentError("`domain` must have a finite length"))
+  isempty(domain) && throw(ArgumentError("`domain` must contain at least one value"))
+  all(value -> value isa Real, domain) || throw(ArgumentError("`domain` values must be real numbers"))
+  allunique(domain) || throw(ArgumentError("`domain` values must be unique"))
 
-  throw(ArgumentError("unsupported domain $(repr(values)); supported domains are [0, 1] and [-1, 1]"))
+  nonnegative_integer = all(
+    value == expected
+    for (value, expected) in zip(domain, 0:(length(domain) - 1))
+  )
+  spin = length(domain) == 2 && all(value -> abs(value) == 1, domain)
+  if !(nonnegative_integer || spin)
+    throw(ArgumentError("unsupported domain $(repr(domain)); use `0:(d - 1)` or a permutation of `[-1, 1]`"))
+  end
+
+  # `diagm` accepts vectors (including ranges), but not every finite iterable.
+  return domain isa AbstractVector ? domain : collect(domain)
 end
 
 """
@@ -73,9 +72,8 @@ Backend-specific keyword arguments:
   For polynomial objectives, constraints are expressed in the same order as their `effective_variables`.
   If the constraints admit no solution at all, the solve does not error: it logs a warning and
   returns `+Inf` together with an infeasible [`Solution`](@ref) (see [`is_feasible`](@ref)).
-- `domain` - The variable domain. Supported values are `[0, 1]` (the default)
-  and `[-1, 1]` for Ising spins. `domain_dim` remains available for the legacy
-  nonnegative integer domain `0:(domain_dim - 1)`; do not pass both keywords.
+- `domain` - Ordered variable values. Defaults to `0:1`; use `[-1, 1]` for
+  Ising spins or `0:(d - 1)` for a nonnegative integer domain of size `d`.
 - `maxdim` - The maximum allowed bond dimension.
   Integer or array of integer specifying the bond dimension per iteration.
   You can use this keyword to control the solver's accuracy vs resources trade-off.
@@ -93,13 +91,12 @@ Backend-specific keyword arguments:
 function minimize(::DMRGBackend, Q::AbstractMatrix{T}, l::AbstractVector{T}, c::T
   ; cutoff=1e-8
   , preprocess::Bool=false
-  , domain = nothing
-  , domain_dim::Union{Nothing,Integer} = nothing
+  , domain = 0:1
   , kwargs...
 ) where T
-  domain_values = normalize_solve_domain(domain, domain_dim)
+  domain_values = validate_solve_domain(domain)
   Qp, lp, permutation = preprocess ? preprocess_qubo(Q, l, cutoff) : (Q, l, collect(1:size(Q, 1)))
-  H      = tensorize(Qp, lp; cutoff, dim = length(domain_values), domain = domain_values)
+  H      = tensorize(Qp, lp; cutoff, domain = domain_values)
   obj(x) = dot(x, Q, x) + dot(l, x) + c
 
   return minimize_mpo(H, c, obj ; cutoff, permutation, domain = domain_values, kwargs...)
@@ -120,12 +117,11 @@ function minimize(
   p::AbstractPolynomial{T}
   ;
   cutoff=1e-8,
-  domain = nothing,
-  domain_dim::Union{Nothing,Integer} = nothing,
+  domain = 0:1,
   kwargs...,
 ) where T
-  domain_values = normalize_solve_domain(domain, domain_dim)
-  H      = tensorize(p; cutoff, dim = length(domain_values), domain = domain_values)
+  domain_values = validate_solve_domain(domain)
+  H      = tensorize(p; cutoff, domain = domain_values)
   cte    = constant_term(p)
   vs     = effective_variables(p)
   obj(x) = real(p(vs => x))
@@ -199,8 +195,7 @@ function tensorize(
   Q::AbstractArray{T},
   rest::Vararg{AbstractArray{T}};
   cutoff = zero(T),
-  dim::Integer,
-  domain = 0:(dim - 1),
+  domain,
 ) where T
   Qs = [Q, rest...]
   if !allequal(Iterators.flatmap(size, Qs))
@@ -208,8 +203,7 @@ function tensorize(
   end
 
   N = size(Q, 1)
-  domain_values = collect(domain)
-  length(domain_values) == dim || throw(DimensionMismatch("domain length must match `dim`"))
+  dim = length(domain)
   sites = ITensors.siteinds("Qudit", N; dim = dim)
   os = OpSum{T}()
 
@@ -221,7 +215,7 @@ function tensorize(
       coeff = sum(k -> t[k...], multiset_permutations(idx, ndims(t)))
 
       if abs(coeff) > cutoff
-        op   = Iterators.flatmap(v -> ("D", (domain = domain_values,), v), idx)
+        op   = Iterators.flatmap(v -> ("D", (domain = domain,), v), idx)
         os .+= (coeff, op...)
       end
     end
@@ -233,12 +227,10 @@ end
 function tensorize(
   p::AbstractPolynomial{T};
   cutoff = zero(T),
-  dim::Integer,
-  domain = 0:(dim - 1),
+  domain,
 ) where T
   N = length(effective_variables(p))
-  domain_values = collect(domain)
-  length(domain_values) == dim || throw(DimensionMismatch("domain length must match `dim`"))
+  dim = length(domain)
   sites = ITensors.siteinds("Qudit", N; dim = dim)
   os = OpSum{T}()
 
@@ -253,7 +245,7 @@ function tensorize(
         map(powers(t)) do p
           v, e = p
           Iterators.flatten(
-            Iterators.repeated(("D", (domain = domain_values,), indices[v]), e),
+            Iterators.repeated(("D", (domain = domain,), indices[v]), e),
           )
         end
       )
@@ -271,7 +263,7 @@ function minimize_mpo( H :: MPO
                      , cutoff      = 1e-8  #  a cutoff of 1E-5 gives sensible accuracy; a cutoff of 1E-8 is high accuracy; and a cutoff of 1E-12 is near exact accuracy. (https://itensor.org/docs.cgi?page=tutorials/dmrg_params)
                      , verbosity   = 1
                      , constraints = AbstractConstraint[]
-                     , domain :: AbstractVector
+                     , domain
                      # Stopping criteria
                      , iterations :: Union{Nothing, Int} = nothing
                      , time_limit = +Inf

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -221,7 +221,7 @@ end
 dfa_to_mpo(dfa::DFA, sites) = dfa_to_mpo(Float64, dfa, sites)
 
 """
-    projection_mpo([T], constraint, sites)
+    projection_mpo([T], constraint, sites; domain)
 
 Build a projection MPO representing a `constraint` applicable to any MPS over `sites`.
 
@@ -233,8 +233,7 @@ Constraint site numbers use the same 1-based register indexing as `sites`.
 # Known constraints
 
 - [`SumConstraint`](@ref) uses a specialized exact integer partial-sum automaton.
-For nonnegative domains and a constraint with rhs `k`, its maximum bond dimension
-is `k+2`. Signed domains use an exact automaton over all reachable partial sums.
+For a constraint with rhs `k`, its maximum bond dimension is `k+2`.
 - [`NotEqualsConstraint`](@ref) uses a specialized MPO with bond dimension `2`,
   independently of the rhs.
 - [`ExactlyOneConstraint`](@ref) uses a specialized MPO with bond dimension `2`
@@ -249,11 +248,8 @@ function projection_mpo(::Type{T}
                        , constraint::AbstractConstraint
                        , sites
                        ; permutation = 1:length(sites)
-                       , domain = nothing) where {T}
-  d = ITensorMPS.dim(sites[1])
-  domain_values = isnothing(domain) ? collect(0:(d - 1)) : collect(domain)
-  length(domain_values) == d || throw(DimensionMismatch("domain length must match the site dimension"))
-  dfa = constraint_to_dfa(constraint, length(sites), domain_values)
+                       , domain) where {T}
+  dfa = constraint_to_dfa(constraint, length(sites), domain)
   dfa_perm = permute_dfa!(dfa, permutation)
   return dfa_to_mpo(T, dfa_perm, sites)
 end
@@ -262,7 +258,7 @@ projection_mpo(constraint::AbstractConstraint, sites; kws...) =
   projection_mpo(Float64, constraint, sites; kws...)
 
 """
-    projection_mpos([T], constraints, sites)
+    projection_mpos([T], constraints, sites; domain)
 
 Build a list of projection MPOs representing  `constraints` applicable to any MPS over `sites`.
 
@@ -358,7 +354,7 @@ function constraint_to_dfa end
 
 function constraint_to_dfa(constraint::SumConstraint{S}, nsites::Integer, alphabet) where {S}
   if minimum(alphabet) < 0
-    return signed_sum_constraint_to_dfa(constraint, nsites, alphabet)
+    throw(ArgumentError("SumConstraint only supports nonnegative domains."))
   end
 
   (; weights, rhs, relation) = constraint
@@ -379,43 +375,6 @@ function constraint_to_dfa(constraint::SumConstraint{S}, nsites::Integer, alphab
   end
 
   return DFA(states, alphabet, initial, accepting, transitions)
-end
-
-function signed_sum_constraint_to_dfa(
-  constraint::SumConstraint{S},
-  nsites::Integer,
-  alphabet,
-) where {S}
-  alphabet_values = collect(alphabet)
-  A = eltype(alphabet_values)
-  initial = zero(S)
-  states = Set{S}([initial])
-
-  # Include sums reachable from every subset of constrained sites. This makes
-  # each transition table valid after the solver permutes tensor sites.
-  for weight in values(constraint.weights)
-    expanded = Set{S}(states)
-    for state in states, value in alphabet_values
-      next_state = convert(S, state + weight * value)
-      push!(expanded, next_state)
-    end
-    states = expanded
-  end
-
-  transitions = map(1:nsites) do site
-    weight = get(constraint.weights, site, zero(S))
-    return Dict(
-      (state, value) => convert(S, state + weight * value)
-      for state in states, value in alphabet_values
-      if convert(S, state + weight * value) in states
-    )
-  end
-
-  accepting = Set(
-    state for state in states
-    if relation_holds(state, constraint.relation, constraint.rhs)
-  )
-  return DFA(sort!(collect(states)), alphabet_values, initial, accepting, transitions)
 end
 
 function constraint_to_dfa(constraint::NotEqualsConstraint{S}, nsites::Integer, alphabet) where {S}

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -233,7 +233,8 @@ Constraint site numbers use the same 1-based register indexing as `sites`.
 # Known constraints
 
 - [`SumConstraint`](@ref) uses a specialized exact integer partial-sum automaton.
-For a constraint with rhs `k`, its maximum bond dimension is `k+2`.
+For nonnegative domains and a constraint with rhs `k`, its maximum bond dimension
+is `k+2`. Signed domains use an exact automaton over all reachable partial sums.
 - [`NotEqualsConstraint`](@ref) uses a specialized MPO with bond dimension `2`,
   independently of the rhs.
 - [`ExactlyOneConstraint`](@ref) uses a specialized MPO with bond dimension `2`
@@ -247,10 +248,12 @@ function projection_mpo end
 function projection_mpo(::Type{T}
                        , constraint::AbstractConstraint
                        , sites
-                       ; permutation = 1:length(sites)) where {T}
+                       ; permutation = 1:length(sites)
+                       , domain = nothing) where {T}
   d = ITensorMPS.dim(sites[1])
-  domain = 0:(d - 1)
-  dfa = constraint_to_dfa(constraint, length(sites), domain)
+  domain_values = isnothing(domain) ? collect(0:(d - 1)) : collect(domain)
+  length(domain_values) == d || throw(DimensionMismatch("domain length must match the site dimension"))
+  dfa = constraint_to_dfa(constraint, length(sites), domain_values)
   dfa_perm = permute_dfa!(dfa, permutation)
   return dfa_to_mpo(T, dfa_perm, sites)
 end
@@ -355,7 +358,7 @@ function constraint_to_dfa end
 
 function constraint_to_dfa(constraint::SumConstraint{S}, nsites::Integer, alphabet) where {S}
   if minimum(alphabet) < 0
-    throw(ArgumentError("SumConstraint only supports nonnegative domains."))
+    return signed_sum_constraint_to_dfa(constraint, nsites, alphabet)
   end
 
   (; weights, rhs, relation) = constraint
@@ -376,6 +379,43 @@ function constraint_to_dfa(constraint::SumConstraint{S}, nsites::Integer, alphab
   end
 
   return DFA(states, alphabet, initial, accepting, transitions)
+end
+
+function signed_sum_constraint_to_dfa(
+  constraint::SumConstraint{S},
+  nsites::Integer,
+  alphabet,
+) where {S}
+  alphabet_values = collect(alphabet)
+  A = eltype(alphabet_values)
+  initial = zero(S)
+  states = Set{S}([initial])
+
+  # Include sums reachable from every subset of constrained sites. This makes
+  # each transition table valid after the solver permutes tensor sites.
+  for weight in values(constraint.weights)
+    expanded = Set{S}(states)
+    for state in states, value in alphabet_values
+      next_state = convert(S, state + weight * value)
+      push!(expanded, next_state)
+    end
+    states = expanded
+  end
+
+  transitions = map(1:nsites) do site
+    weight = get(constraint.weights, site, zero(S))
+    return Dict(
+      (state, value) => convert(S, state + weight * value)
+      for state in states, value in alphabet_values
+      if convert(S, state + weight * value) in states
+    )
+  end
+
+  accepting = Set(
+    state for state in states
+    if relation_holds(state, constraint.relation, constraint.rhs)
+  )
+  return DFA(sort!(collect(states)), alphabet_values, initial, accepting, transitions)
 end
 
 function constraint_to_dfa(constraint::NotEqualsConstraint{S}, nsites::Integer, alphabet) where {S}

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -16,6 +16,7 @@ Use [`sample`](@ref) to draw vectors from it.
 - `bond_dims`: maximum MPS bond dimension at each iteration.
 - `elapsed_times`: wall-clock time in seconds from the start of the solve at each iteration.
 - `permutation`: original variable index represented by each tensor site.
+- `domain`: physical variable values, ordered to match the local tensor basis.
 
 The three stats vectors are parallel — `energies[i]`, `bond_dims[i]`, and `elapsed_times[i]`
 all correspond to iteration `i`.
@@ -23,15 +24,36 @@ all correspond to iteration `i`.
 Provably infeasible models produce a `Solution` with no MPS and empty stats
 vectors; check with [`is_feasible`](@ref) before sampling.
 """
-struct Solution{T <: Real}
+struct Solution{T <: Real, D <: Real}
     tensor        :: Union{MPS, Nothing}
     energies      :: Vector{T}
     bond_dims     :: Vector{Int}
     elapsed_times :: Vector{Float64}
     permutation   :: Vector{Int}
+    domain        :: Vector{D}
 end
 
 identity_permutation(tensor::MPS) = collect(1:length(siteinds(tensor)))
+default_domain(tensor::MPS) = collect(0:(ITensorMPS.dim(first(siteinds(tensor))) - 1))
+
+Solution{T}(
+  tensor::MPS,
+  energies::Vector{T},
+  bond_dims::Vector{Int},
+  elapsed_times::Vector{Float64},
+  permutation::Vector{Int},
+  domain::AbstractVector{D},
+) where {T <: Real, D <: Real} =
+  Solution{T,D}(tensor, energies, bond_dims, elapsed_times, permutation, collect(D, domain))
+
+Solution{T}(
+  tensor::MPS,
+  energies::Vector{T},
+  bond_dims::Vector{Int},
+  elapsed_times::Vector{Float64},
+  permutation::Vector{Int},
+) where {T <: Real} =
+  Solution{T}(tensor, energies, bond_dims, elapsed_times, permutation, default_domain(tensor))
 
 Solution{T}(
   tensor::MPS,
@@ -47,8 +69,11 @@ Solution(
   elapsed_times::Vector{Float64},
 ) where {T <: Real} = Solution{T}(tensor, energies, bond_dims, elapsed_times)
 
-infeasible_solution(::Type{T}) where {T <: Real} =
-  Solution{T}(nothing, T[], Int[], Float64[], Int[])
+infeasible_solution(::Type{T}) where {T <: Real} = infeasible_solution(T, Int[])
+
+function infeasible_solution(::Type{T}, domain::AbstractVector{D}) where {T <: Real, D <: Real}
+  return Solution{T,D}(nothing, T[], Int[], Float64[], Int[], collect(D, domain))
+end
 
 """
     is_feasible(psi::Solution)
@@ -63,7 +88,6 @@ is_feasible(psi::Solution) = !isnothing(psi.tensor)
 
 original_order(bs, permutation) = bs[invperm(permutation)]
 
-# Sample from |ψ> in the {0, 1} world instead of 1-based Julia index world.
 """
     sample(psi)
 
@@ -74,7 +98,7 @@ since there is no solution to query.
 """
 function sample(psi::Solution)
   if is_feasible(psi)
-    bs = ITensorMPS.sample!(psi.tensor) .- 1
+    bs = psi.domain[ITensorMPS.sample!(psi.tensor)]
     return original_order(bs, psi.permutation)
   else
     throw(DomainError("the model is infeasible; there is no solution to sample"))
@@ -95,14 +119,20 @@ function Base.in(bs, psi::Solution; cutoff = 1e-8)
 end
 
 function prob(psi::Solution{T}, bs) where {T}
-  return is_feasible(psi) ? abs2(coeff(psi, bs)) : zero(T)
+  valid = length(bs) == length(psi.permutation) && all(in(psi.domain), bs)
+  return is_feasible(psi) && valid ? abs2(coeff(psi, bs)) : zero(T)
 end
 
 function coeff(psi::Solution, bs)
   tn    = psi.tensor
   sites = siteinds(tn)
   bs    = bs[psi.permutation]
-  psi0  = MPS(sites, string.(Int.(bs)))
+  positions = map(bs) do value
+    position = findfirst(==(value), psi.domain)
+    isnothing(position) && throw(DomainError(value, "value is outside the solution domain $(psi.domain)"))
+    return position - 1
+  end
+  psi0  = MPS(sites, string.(positions))
 
   return inner(psi0,  tn)
 end

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -12,11 +12,11 @@ Use [`sample`](@ref) to draw vectors from it.
 ## Fields
 
 - `tensor`: the underlying MPS, or `nothing` when the model is infeasible.
+- `domain`: possible variable values.
+- `permutation`: original variable index represented by each tensor site.
 - `energies`: expected objective value of the problem recorded at each iteration of the solver.
 - `bond_dims`: maximum MPS bond dimension at each iteration.
 - `elapsed_times`: wall-clock time in seconds from the start of the solve at each iteration.
-- `permutation`: original variable index represented by each tensor site.
-- `domain`: physical variable values, ordered to match the local tensor basis.
 
 The three stats vectors are parallel — `energies[i]`, `bond_dims[i]`, and `elapsed_times[i]`
 all correspond to iteration `i`.
@@ -26,26 +26,26 @@ vectors; check with [`is_feasible`](@ref) before sampling.
 """
 struct Solution{T <: Real}
     tensor        :: Union{MPS, Nothing}
+    domain        :: Vector{T}
+    permutation   :: Vector{Int}
     energies      :: Vector{T}
     bond_dims     :: Vector{Int}
     elapsed_times :: Vector{Float64}
-    permutation   :: Vector{Int}
-    domain        :: Vector{T}
 
     function Solution{T}(
       tensor::Union{MPS,Nothing},
+      domain,
+      permutation::Vector{Int},
       energies::Vector{T},
       bond_dims::Vector{Int},
       elapsed_times::Vector{Float64},
-      permutation::Vector{Int},
-      domain,
     ) where {T <: Real}
-      return new{T}(tensor, energies, bond_dims, elapsed_times, permutation, collect(T, domain))
+      return new{T}(tensor, domain, permutation, energies, bond_dims, elapsed_times)
     end
 end
 
 function infeasible_solution(::Type{T}, domain) where {T <: Real}
-  return Solution{T}(nothing, T[], Int[], Float64[], Int[], domain)
+  return Solution{T}(nothing, domain, Int[], T[], Int[], Float64[])
 end
 
 """
@@ -101,7 +101,9 @@ function coeff(psi::Solution, bs)
   bs    = bs[psi.permutation]
   positions = map(bs) do value
     position = findfirst(==(value), psi.domain)
-    isnothing(position) && throw(DomainError(value, "value is outside the solution domain $(psi.domain)"))
+    if isnothing(position)
+      throw(DomainError(value, "value is outside the solution domain $(psi.domain)"))
+    end
     return position - 1
   end
   # Qudit state names are zero-based basis positions, not physical domain values.

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -24,55 +24,28 @@ all correspond to iteration `i`.
 Provably infeasible models produce a `Solution` with no MPS and empty stats
 vectors; check with [`is_feasible`](@ref) before sampling.
 """
-struct Solution{T <: Real, D <: Real}
+struct Solution{T <: Real}
     tensor        :: Union{MPS, Nothing}
     energies      :: Vector{T}
     bond_dims     :: Vector{Int}
     elapsed_times :: Vector{Float64}
     permutation   :: Vector{Int}
-    domain        :: Vector{D}
+    domain        :: Vector{T}
+
+    function Solution{T}(
+      tensor::Union{MPS,Nothing},
+      energies::Vector{T},
+      bond_dims::Vector{Int},
+      elapsed_times::Vector{Float64},
+      permutation::Vector{Int},
+      domain,
+    ) where {T <: Real}
+      return new{T}(tensor, energies, bond_dims, elapsed_times, permutation, collect(T, domain))
+    end
 end
 
-identity_permutation(tensor::MPS) = collect(1:length(siteinds(tensor)))
-default_domain(tensor::MPS) = collect(0:(ITensorMPS.dim(first(siteinds(tensor))) - 1))
-
-Solution{T}(
-  tensor::MPS,
-  energies::Vector{T},
-  bond_dims::Vector{Int},
-  elapsed_times::Vector{Float64},
-  permutation::Vector{Int},
-  domain::AbstractVector{D},
-) where {T <: Real, D <: Real} =
-  Solution{T,D}(tensor, energies, bond_dims, elapsed_times, permutation, collect(D, domain))
-
-Solution{T}(
-  tensor::MPS,
-  energies::Vector{T},
-  bond_dims::Vector{Int},
-  elapsed_times::Vector{Float64},
-  permutation::Vector{Int},
-) where {T <: Real} =
-  Solution{T}(tensor, energies, bond_dims, elapsed_times, permutation, default_domain(tensor))
-
-Solution{T}(
-  tensor::MPS,
-  energies::Vector{T},
-  bond_dims::Vector{Int},
-  elapsed_times::Vector{Float64},
-) where {T <: Real} = Solution{T}(tensor, energies, bond_dims, elapsed_times, identity_permutation(tensor))
-
-Solution(
-  tensor::MPS,
-  energies::Vector{T},
-  bond_dims::Vector{Int},
-  elapsed_times::Vector{Float64},
-) where {T <: Real} = Solution{T}(tensor, energies, bond_dims, elapsed_times)
-
-infeasible_solution(::Type{T}) where {T <: Real} = infeasible_solution(T, Int[])
-
-function infeasible_solution(::Type{T}, domain::AbstractVector{D}) where {T <: Real, D <: Real}
-  return Solution{T,D}(nothing, T[], Int[], Float64[], Int[], collect(D, domain))
+function infeasible_solution(::Type{T}, domain) where {T <: Real}
+  return Solution{T}(nothing, T[], Int[], Float64[], Int[], domain)
 end
 
 """
@@ -119,8 +92,7 @@ function Base.in(bs, psi::Solution; cutoff = 1e-8)
 end
 
 function prob(psi::Solution{T}, bs) where {T}
-  valid = length(bs) == length(psi.permutation) && all(in(psi.domain), bs)
-  return is_feasible(psi) && valid ? abs2(coeff(psi, bs)) : zero(T)
+  return is_feasible(psi) ? abs2(coeff(psi, bs)) : zero(T)
 end
 
 function coeff(psi::Solution, bs)
@@ -132,6 +104,7 @@ function coeff(psi::Solution, bs)
     isnothing(position) && throw(DomainError(value, "value is outside the solution domain $(psi.domain)"))
     return position - 1
   end
+  # Qudit state names are zero-based basis positions, not physical domain values.
   psi0  = MPS(sites, string.(positions))
 
   return inner(psi0,  tn)

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -75,6 +75,15 @@ By default, it uses DMRG to calculate the optimal solution.
 
 Keyword arguments:
 
+- `constraints :: AbstractVector{<:AbstractConstraint}` - Experimental native Julia hard constraints.
+  Defaults to `AbstractConstraint[]`. In constrained DMRG solves, TenSolver lowers each constraint to
+  a projection MPO, solves the projected Hamiltonian, and returns a feasible sampled assignment.
+  For polynomial objectives, constraints are expressed in the same order as their `effective_variables`.
+  If the constraints admit no solution at all, the solve does not error: it logs a warning and
+  returns `+Inf` together with an infeasible [`Solution`](@ref) (see [`is_feasible`](@ref)).
+- `domain` - Possible variable values. Defaults to `[0, 1]`;
+  Use `[-1, 1]` for Ising spins or `0:(d - 1)` for a nonnegative integer domain of size `d`.
+  Domains are sorted and deduplicated before solving.
 - `iterations :: Int` - Maximum iterations the solver should run. Defaults to `10`.
 - `cutoff :: Float64` - Any absolute value below this threshold is considered zero. Defaults to `1e-8`.
   You can use this keyword to control the solver's accuracy vs resources trade-off.
@@ -98,6 +107,9 @@ Keyword arguments:
 
   Other keywords might be available depending on the chosen backend.
   See the documentation for each backend for comprehensive lists.
+
+  Some keywords, such as `constraints` and `domain`,
+  may have limited support depending on the backend.
 
 The returned `Solution` carries per-iteration stats in the fields `energies`, `bond_dims`, and `elapsed_times`.
 

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -85,9 +85,6 @@ Keyword arguments:
 - `preprocess :: Bool` - Defaults to `false`. If `true`, permute QUBO variables before constructing the MPS Hamiltonian
   so coupled variables are closer in the one-dimensional tensor order. Samples are returned in the
   caller's original variable order. This is an experimental feature and may be subject to changes.
-- `domain` - Variable values. The DMRG backend supports `[0, 1]` (the default)
-  and the Ising domain `[-1, 1]`. The legacy `domain_dim = d` spelling remains
-  available for `0:(d - 1)`; these keywords cannot be combined.
 - `on_iteration :: Function` - Called after each recorded iteration as
   `f(psi::MPS; iteration, objective, bond_dim, elapsed_time)`.
   `objective` is the expected objective function ⟨ψ|H|ψ⟩ at this iteration.

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -61,13 +61,13 @@ const default_backend = DMRGBackend()
 """
     minimize(Q::Matrix[, l::Vector[, c::Number ; device, cutoff, kwargs...)
 
-Solve the Quadratic Unconstrained Binary Optimization (QUBO) problem
+Solve a quadratic discrete optimization problem
 
-    min  b'Qb + l'b + c
-    s.t. b_i in {0, 1}
+    min  x'Qx + l'x + c
+    s.t. x_i in domain
 
 Return the optimal value `E` and a probability distribution `ψ` over optimal solutions.
-You can use [`sample`](@ref) to get an actual bitstring from `ψ`.
+You can use [`sample`](@ref) to get an actual solution vector from `ψ`.
 
 There are multiple backends available, selected through the keyword `backend`.
 By default, it uses DMRG to calculate the optimal solution.
@@ -85,6 +85,9 @@ Keyword arguments:
 - `preprocess :: Bool` - Defaults to `false`. If `true`, permute QUBO variables before constructing the MPS Hamiltonian
   so coupled variables are closer in the one-dimensional tensor order. Samples are returned in the
   caller's original variable order. This is an experimental feature and may be subject to changes.
+- `domain` - Variable values. The DMRG backend supports `[0, 1]` (the default)
+  and the Ising domain `[-1, 1]`. The legacy `domain_dim = d` spelling remains
+  available for `0:(d - 1)`; these keywords cannot be combined.
 - `on_iteration :: Function` - Called after each recorded iteration as
   `f(psi::MPS; iteration, objective, bond_dim, elapsed_time)`.
   `objective` is the expected objective function ⟨ψ|H|ψ⟩ at this iteration.

--- a/test/constrained_solve.jl
+++ b/test/constrained_solve.jl
@@ -186,7 +186,15 @@ end
       on_iteration=(mps; iteration, objective, kw...) -> begin
         push!(calls, iteration)
         push!(objectives, objective)
-        @test is_feasible(TenSolver.sample(TenSolver.Solution(deepcopy(mps), Float64[], Int[], Float64[])), constraints)
+        callback_solution = TenSolver.Solution{Float64}(
+          deepcopy(mps),
+          Float64[],
+          Int[],
+          Float64[],
+          collect(1:length(mps)),
+          0:1,
+        )
+        @test is_feasible(TenSolver.sample(callback_solution), constraints)
       end,
     )
 

--- a/test/constrained_solve.jl
+++ b/test/constrained_solve.jl
@@ -188,11 +188,11 @@ end
         push!(objectives, objective)
         callback_solution = TenSolver.Solution{Float64}(
           deepcopy(mps),
+          0:1,
+          collect(1:length(mps)),
           Float64[],
           Int[],
           Float64[],
-          collect(1:length(mps)),
-          0:1,
         )
         @test is_feasible(TenSolver.sample(callback_solution), constraints)
       end,

--- a/test/domains.jl
+++ b/test/domains.jl
@@ -106,6 +106,16 @@ import DynamicPolynomials
     @test is_feasible(sample(psi), constraints)
   end
 
+  @testset "Zero domain" begin
+    Q = [-1.0 0.0; 1.0 2.0]
+    E, psi = minimize(Q; domain = [0], verbosity = 0)
+    x = TenSolver.sample(psi)
+
+    @test E == 0
+    @test [0, 0] in psi
+    @test x == [0, 0]
+  end
+
   @testset "Domain API and validation" begin
     Q = [-1.0 0.0; 0.0 2.0]
 
@@ -119,13 +129,12 @@ import DynamicPolynomials
     E_ordered, psi_ordered = minimize([1.0]; domain = [1, -1], verbosity = 0)
     @test E_ordered ≈ -1.0
     @test sample(psi_ordered) == [-1.0]
-    @test psi_ordered.domain == [1.0, -1.0]
+    @test psi_ordered.domain == [-1.0, 1.0]
     @test [-1] in psi_ordered
     @test [1] ∉ psi_ordered
     @test_throws DomainError [2] in psi_ordered
 
     @test_throws ArgumentError minimize(Q; domain = Int[], verbosity = 0)
-    @test_throws ArgumentError minimize(Q; domain = [0, 0], verbosity = 0)
     @test_throws ArgumentError minimize(Q; domain = [0, 2], verbosity = 0)
     @test_throws ArgumentError minimize(Q; domain = ["0", "1"], verbosity = 0)
   end

--- a/test/domains.jl
+++ b/test/domains.jl
@@ -9,7 +9,7 @@ import DynamicPolynomials
     ]
     obj(x) = dot(x, Q, x)
 
-    E, psi = minimize(Q; domain_dim = 3, iterations = 5, cutoff = 1e-12, verbosity = 0)
+    E, psi = minimize(Q; domain = 0:2, iterations = 5, cutoff = 1e-12, verbosity = 0)
 
     @test E ≈ 0.0
     @test [0, 0, 0] in psi
@@ -19,7 +19,7 @@ import DynamicPolynomials
     l = [-1.0,  2.0, -3.0]
     obj(x) = dot(l, x)
 
-    E, psi = minimize(l; domain_dim = 3, iterations = 5, cutoff = 1e-12, verbosity = 0)
+    E, psi = minimize(l; domain = 0:2, iterations = 5, cutoff = 1e-12, verbosity = 0)
     E0, x0 = brute_force(obj, 3; domain = 0:2)
 
     @test E ≈ -8
@@ -35,7 +35,7 @@ import DynamicPolynomials
     l = [-2.0, -1.0, -3.0]
     obj(x) = dot(x, Q, x) + dot(l, x)
 
-    E, psi = minimize(Q, l; domain_dim = 3, iterations = 5, cutoff = 1e-12, verbosity = 0)
+    E, psi = minimize(Q, l; domain = 0:2, iterations = 5, cutoff = 1e-12, verbosity = 0)
     E0, x0 = brute_force(obj, 3; domain = 0:2)
 
     @test E ≈ E0
@@ -48,7 +48,7 @@ import DynamicPolynomials
     c = 5.0
     obj(x) = dot(x, Q, x) + dot(l, x)
 
-    E, psi = minimize(Q, l, c; domain_dim = 3, verbosity = 0)
+    E, psi = minimize(Q, l, c; domain = 0:2, verbosity = 0)
     E0, x0 = brute_force(obj, 1; domain = 0:2)
 
     @test E ≈ 3.0
@@ -60,7 +60,7 @@ import DynamicPolynomials
     p = y[1]^2 + y[1] * y[2] + 2y[2]^2 - y[2] * y[3] - 3.0y[3]
     obj(x) = p(y => x)
 
-    E, psi = minimize(p; domain_dim = 3, iterations = 10, mindim = 5, cutoff = 1e-8, verbosity = 0)
+    E, psi = minimize(p; domain = 0:2, iterations = 10, mindim = 5, cutoff = 1e-8, verbosity = 0)
     E0, x0 = brute_force(obj, 3; domain = 0:2)
 
     @test E ≈ E0
@@ -71,7 +71,7 @@ import DynamicPolynomials
     DynamicPolynomials.@polyvar y[1:2]
     p = 2.0y[1]^2 - 3.0y[1] + 2.0y[2]^2 - 3.0y[2]
 
-    E, psi = maximize(p; domain_dim = 3, iterations = 5, cutoff = 1e-12, verbosity = 0)
+    E, psi = maximize(p; domain = 0:2, iterations = 5, cutoff = 1e-12, verbosity = 0)
 
     @test E ≈ 4.0
     @test [2, 2] in psi
@@ -94,7 +94,7 @@ import DynamicPolynomials
       Q,
       l;
       constraints,
-      domain_dim = 3,
+      domain = 0:2,
       iterations = 5,
       cutoff = 1e-8,
       mindim = 10,
@@ -104,5 +104,29 @@ import DynamicPolynomials
 
     @test E ≈ E0
     @test is_feasible(sample(psi), constraints)
+  end
+
+  @testset "Domain API and validation" begin
+    Q = [-1.0 0.0; 0.0 2.0]
+
+    E_default, psi_default = minimize(Q; iterations = 4, verbosity = 0)
+    E_bool, psi_bool = minimize(Q; domain = [0, 1], iterations = 4, verbosity = 0)
+
+    @test E_default ≈ E_bool
+    @test sample(psi_default) == [1, 0]
+    @test [1, 0] in psi_bool
+
+    E_ordered, psi_ordered = minimize([1.0]; domain = [1, -1], verbosity = 0)
+    @test E_ordered ≈ -1.0
+    @test sample(psi_ordered) == [-1.0]
+    @test psi_ordered.domain == [1.0, -1.0]
+    @test [-1] in psi_ordered
+    @test [1] ∉ psi_ordered
+    @test_throws DomainError [2] in psi_ordered
+
+    @test_throws ArgumentError minimize(Q; domain = Int[], verbosity = 0)
+    @test_throws ArgumentError minimize(Q; domain = [0, 0], verbosity = 0)
+    @test_throws ArgumentError minimize(Q; domain = [0, 2], verbosity = 0)
+    @test_throws ArgumentError minimize(Q; domain = ["0", "1"], verbosity = 0)
   end
 end

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -9,7 +9,7 @@ function mpo_diagonal(H, sites, bits)
 end
 
 function assert_projection_matches_feasibility(constraint, sites)
-  H = TenSolver.projection_mpo(constraint, sites)
+  H = TenSolver.projection_mpo(constraint, sites; domain = 0:1)
 
   for bits in all_bitstrings(sites)
     expected = Float64(is_feasible(collect(bits), constraint))
@@ -145,14 +145,14 @@ end
        0.25 -2.00  0.75
       -0.50  0.75  3.00
     ]
-    H = TenSolver.tensorize(Q; dim = 2)
+    H = TenSolver.tensorize(Q; domain = 0:1)
     sites = ITensorMPS.siteinds(first, H; plev=0)
 
     constraints = AbstractConstraint[
       NotEqualsConstraint([1, 2], [1, 1]),
       ExactlyOneConstraint([1, 3], 0),
     ]
-    projections = TenSolver.projection_mpos(constraints, sites)
+    projections = TenSolver.projection_mpos(constraints, sites; domain = 0:1)
 
     @test ITensorMPS.maxlinkdim(projections[1]) <= 2
 
@@ -192,7 +192,7 @@ end
     perm = [3, 1, 4, 2]
 
     constraint = RelationConstraint(1, :(<=), 4)
-    H = TenSolver.projection_mpo(constraint, sites; permutation=perm)
+    H = TenSolver.projection_mpo(constraint, sites; permutation=perm, domain = 0:1)
 
     for bits in all_bitstrings(sites)
       # tensor-order bits -> original-order bits
@@ -212,7 +212,7 @@ end
       RelationConstraint(3, :(>=), 1),
     ]
 
-    Hs = TenSolver.projection_mpos(constraints, sites; permutation=perm)
+    Hs = TenSolver.projection_mpos(constraints, sites; permutation=perm, domain = 0:1)
 
     @test length(Hs) == length(constraints)
 
@@ -226,10 +226,10 @@ end
   end
 
   @testset "Infeasible projections remain zero" begin
-    H = TenSolver.tensorize([1.0 0.5; 0.5 2.0]; dim = 2)
+    H = TenSolver.tensorize([1.0 0.5; 0.5 2.0]; domain = 0:1)
     sites = ITensorMPS.siteinds(first, H; plev=0)
     impossible = SumConstraint([1, 2], [1, 1], :(==), 3)
-    P = TenSolver.projection_mpo(impossible, sites)
+    P = TenSolver.projection_mpo(impossible, sites; domain = 0:1)
 
     H_eff = TenSolver.project_hamiltonian(H, P; cutoff=1e-12)
     psi = ITensorMPS.MPS(sites, fill("full", length(sites)))
@@ -260,7 +260,7 @@ end
       NotEqualsConstraint([i, i + 1], [1, 1])
       for i in 1:3
     ]
-    Hs = TenSolver.projection_mpos(local_exclusions, sites)
+    Hs = TenSolver.projection_mpos(local_exclusions, sites; domain = 0:1)
 
     for (constraint, local_H) in zip(local_exclusions, Hs)
       left, right = TenSolver.constraint_sites(constraint)
@@ -344,7 +344,7 @@ end
 
     for constraint in constraints
       dfa = TenSolver.constraint_to_dfa(constraint, length(sites), 0:1)
-      H = TenSolver.projection_mpo(constraint, sites)
+      H = TenSolver.projection_mpo(constraint, sites; domain = 0:1)
 
       for bits in all_bitstrings(sites)
         expected = is_feasible(collect(bits), constraint)
@@ -356,6 +356,12 @@ end
         @test mpo_diagonal(H, sites, bits) ≈ expected
       end
     end
+
+    @test_throws ArgumentError TenSolver.projection_mpo(
+      SumConstraint([1], [1], 1; relation=:(==)),
+      ITensors.siteinds("Qudit", 1; dim=2);
+      domain = [-1, 1],
+    )
   end
 
   @testset "SumConstraint bond dimension scales with capacity, not size" begin
@@ -368,6 +374,7 @@ end
       TenSolver.projection_mpo(
         SumConstraint(sitelist, weights, rhs; relation=:(<=)),
         ITensors.siteinds("Qudit", maximum(sitelist); dim=2),
+        domain = 0:1,
       ),
     )
 
@@ -389,10 +396,10 @@ end
        0.0  0.0   0.0 -1.0  0.25
        0.0  0.0   0.0  0.0  2.0
     ]
-    H = TenSolver.tensorize(Q, diag(Q); dim = 2)
+    H = TenSolver.tensorize(Q, diag(Q); domain = 0:1)
     sites = ITensorMPS.siteinds(first, H; plev=0)
     sum_constraint = SumConstraint([1, 2, 3, 4, 5], ones(Int, 5), 2; relation=:(<=))
-    projections = TenSolver.projection_mpos([sum_constraint], sites)
+    projections = TenSolver.projection_mpos([sum_constraint], sites; domain = 0:1)
     @test ITensorMPS.maxlinkdim(projections[1]) <= 2 + 2
     H_eff = TenSolver.project_hamiltonian(H, projections; cutoff=1e-12)
     @test ITensorMPS.maxlinkdim(H_eff) <= ITensorMPS.maxlinkdim(H) * (2 + 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ include(filepath("projection_mpo.jl"))
 include(filepath("qubo.jl"))
 include(filepath("pubo.jl"))
 include(filepath("domains.jl"))
+include(filepath("spin_domains.jl"))
 include(filepath("constrained_solve.jl"))
 
 # JuMP interface

--- a/test/spin_domains.jl
+++ b/test/spin_domains.jl
@@ -1,0 +1,131 @@
+import DynamicPolynomials
+
+@testset "Spin domains" begin
+  spin_domain = [-1, 1]
+
+  @testset "Quadratic objective" begin
+    J = [
+       0.5  -1.0   0.25
+       0.0   0.0  -0.75
+       0.5   0.0   1.0
+    ]
+    h = [0.25, -1.5, 0.75]
+    offset = 2.0
+    obj(s) = dot(s, J, s) + dot(h, s) + offset
+
+    E, psi = minimize(
+      J,
+      h,
+      offset;
+      domain = spin_domain,
+      iterations = 8,
+      mindim = 8,
+      cutoff = 1e-12,
+      verbosity = 0,
+    )
+    E0, s0 = brute_force(obj, 3; domain = spin_domain)
+
+    @test E ≈ E0
+    @test s0 in psi
+    @test all(in(spin_domain), sample(psi))
+    @test [0, 0, 0] ∉ psi
+  end
+
+  @testset "Single-site and maximize" begin
+    J = reshape([2.0], 1, 1)
+    h = [-3.0]
+    obj(s) = dot(s, J, s) + dot(h, s)
+
+    E, psi = minimize(J, h; domain = (-1, 1), verbosity = 0)
+    Emax, psimax = maximize(J, h; domain = spin_domain, verbosity = 0)
+
+    @test E ≈ obj([1])
+    @test sample(psi) == [1]
+    @test Emax ≈ obj([-1])
+    @test sample(psimax) == [-1]
+  end
+
+  @testset "Polynomial objective" begin
+    DynamicPolynomials.@polyvar s[1:3]
+    p = 1.5s[1] * s[2] - 2.0s[2] * s[3] + 0.5s[1]^2 + s[3]
+    obj(x) = real(p(s => x))
+
+    E, psi = minimize(
+      p;
+      domain = spin_domain,
+      iterations = 8,
+      mindim = 8,
+      cutoff = 1e-12,
+      verbosity = 0,
+    )
+    E0, s0 = brute_force(obj, 3; domain = spin_domain)
+
+    @test E ≈ E0
+    @test s0 in psi
+  end
+
+  @testset "Constraints use physical Spin values" begin
+    J = [
+      0.0  0.0  0.5
+      0.0  0.0 -0.5
+      0.5 -0.5  0.0
+    ]
+    h = [-3.0, -2.0, -1.0]
+    constraints = AbstractConstraint[
+      SumConstraint([1, 2, 3], [1, 2, 3], 0; relation = :(==)),
+      NotEqualsConstraint([1, 2], [1, 1]),
+    ]
+    obj(s) = dot(s, J, s) + dot(h, s)
+
+    E, psi = minimize(
+      J,
+      h;
+      domain = spin_domain,
+      constraints,
+      preprocess = true,
+      iterations = 8,
+      mindim = 8,
+      cutoff = 1e-12,
+      verbosity = 0,
+    )
+    E0, s0 = brute_force(obj, 3, constraints; domain = spin_domain)
+    sampled = sample(psi)
+
+    @test E ≈ E0
+    @test s0 in psi
+    @test psi.permutation != collect(1:3)
+    @test is_feasible(sampled, constraints)
+    @test all(in(spin_domain), sampled)
+  end
+
+  @testset "Infeasible Spin constraints preserve the domain" begin
+    impossible = AbstractConstraint[
+      SumConstraint([1], [1], 2; relation = :(==)),
+    ]
+
+    E, psi = minimize([0.0]; domain = spin_domain, constraints = impossible, verbosity = 0)
+
+    @test E == Inf
+    @test !is_feasible(psi)
+    @test psi.domain == spin_domain
+    @test [1] ∉ psi
+    @test_throws DomainError sample(psi)
+  end
+
+  @testset "Domain validation and compatibility" begin
+    Q = [-1.0 0.0; 0.0 2.0]
+
+    E_default, psi_default = minimize(Q; iterations = 4, verbosity = 0)
+    E_bool, psi_bool = minimize(Q; domain = [0, 1], iterations = 4, verbosity = 0)
+    E_dim, psi_dim = minimize(Q; domain_dim = 2, iterations = 4, verbosity = 0)
+
+    @test E_default ≈ E_bool ≈ E_dim
+    @test sample(psi_default) == [1, 0]
+    @test [1, 0] in psi_bool
+    @test [1, 0] in psi_dim
+
+    @test_throws ArgumentError minimize(Q; domain = [0, 2], verbosity = 0)
+    @test_throws ArgumentError minimize(Q; domain = [1, -1], verbosity = 0)
+    @test_throws ArgumentError minimize(Q; domain = [-1, 1], domain_dim = 2, verbosity = 0)
+  end
+end

--- a/test/spin_domains.jl
+++ b/test/spin_domains.jl
@@ -35,7 +35,7 @@ import DynamicPolynomials
     h = [-3.0]
     obj(s) = dot(s, J, s) + dot(h, s)
 
-    E, psi = minimize(J, h; domain = (-1, 1), verbosity = 0)
+    E, psi = minimize(J, h; domain = [-1, 1], verbosity = 0)
     Emax, psimax = maximize(J, h; domain = spin_domain, verbosity = 0)
 
     @test E ≈ obj([1])

--- a/test/spin_domains.jl
+++ b/test/spin_domains.jl
@@ -28,7 +28,6 @@ import DynamicPolynomials
     @test E ≈ E0
     @test s0 in psi
     @test all(in(spin_domain), sample(psi))
-    @test [0, 0, 0] ∉ psi
   end
 
   @testset "Single-site and maximize" begin
@@ -72,8 +71,8 @@ import DynamicPolynomials
     ]
     h = [-3.0, -2.0, -1.0]
     constraints = AbstractConstraint[
-      SumConstraint([1, 2, 3], [1, 2, 3], 0; relation = :(==)),
       NotEqualsConstraint([1, 2], [1, 1]),
+      RelationConstraint(1, :(!=), 3),
     ]
     obj(s) = dot(s, J, s) + dot(h, s)
 
@@ -100,7 +99,8 @@ import DynamicPolynomials
 
   @testset "Infeasible Spin constraints preserve the domain" begin
     impossible = AbstractConstraint[
-      SumConstraint([1], [1], 2; relation = :(==)),
+      NotEqualsConstraint([1], [-1]),
+      NotEqualsConstraint([1], [1]),
     ]
 
     E, psi = minimize([0.0]; domain = spin_domain, constraints = impossible, verbosity = 0)
@@ -112,20 +112,4 @@ import DynamicPolynomials
     @test_throws DomainError sample(psi)
   end
 
-  @testset "Domain validation and compatibility" begin
-    Q = [-1.0 0.0; 0.0 2.0]
-
-    E_default, psi_default = minimize(Q; iterations = 4, verbosity = 0)
-    E_bool, psi_bool = minimize(Q; domain = [0, 1], iterations = 4, verbosity = 0)
-    E_dim, psi_dim = minimize(Q; domain_dim = 2, iterations = 4, verbosity = 0)
-
-    @test E_default ≈ E_bool ≈ E_dim
-    @test sample(psi_default) == [1, 0]
-    @test [1, 0] in psi_bool
-    @test [1, 0] in psi_dim
-
-    @test_throws ArgumentError minimize(Q; domain = [0, 2], verbosity = 0)
-    @test_throws ArgumentError minimize(Q; domain = [1, -1], verbosity = 0)
-    @test_throws ArgumentError minimize(Q; domain = [-1, 1], domain_dim = 2, verbosity = 0)
-  end
 end


### PR DESCRIPTION
## Summary

- add `domain = [-1, 1]` support for quadratic and polynomial DMRG solves while keeping `0:1` as the Boolean default
- use `domain` as the single public spelling, including `domain = 0:(d - 1)` for nonnegative integer domains
- carry ordered physical domain values through Hamiltonian operators, explicit internal APIs, `Solution` sampling and probability queries, infeasible results, and constraint projection MPOs
- accept either Spin ordering while rejecting empty, duplicate, non-real, and otherwise unsupported domains at the public boundary
- retain the v1 nonnegative-domain assumption for `SumConstraint`; other constraint types continue to operate on physical Spin values

## Validation

- `julia +release --project=. -e 'using Pkg; Pkg.test()'`
- targeted projection, non-binary-domain, Spin-domain, constrained-solve, and JuMP suites
- Documenter doctests and Aqua

## Related work

- builds on the domain-independent constraint and qudit groundwork merged in #105
- completes the Ising/Spin child of #67; arbitrary finite domains and independent per-variable domains remain separate follow-up work

## Branch hygiene

- base: `main` at `7e0fb9f94c8ff16c1d6cbe0213a32a06e0778397`
- head: `feat/issue-106-spin-domains`; not stacked and has no prerequisite PR
- open PRs #31, #44, and #45 substantially change `src/solution.jl` and/or `src/solver.jl`; they should reconcile their backend-specific solution/Ising APIs after this PR lands
- open PR #46 shares `docs/src/examples.md` and `test/runtests.jl`, but its current hunks are non-adjacent

Closes #106
