### PR TITLE
Document fractional domains and add constraint regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Pkg.add("TenSolver")
 ## Usage
 
 The simplest way to use this package is passing a matrix to the solver,
-while defining an integer domain.
+while defining a finite domain of real values.
 
 ```julia
 using TenSolver

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -70,6 +70,29 @@ x = TenSolver.sample(psi)
 (true, [-2.0, 3.0, -2.0], [-2.0, 0.0, 3.0])
 ```
 
+## Fractional Domains
+
+Unconstrained DMRG optimization accepts any finite domain of real values,
+including fractional values:
+
+```jldoctest fractional-domain
+using TenSolver
+
+l = [-2.0, 3.0]
+
+E, psi = TenSolver.minimize(l; domain = [0.0, 0.5, 1.0], verbosity = 0)
+x = TenSolver.sample(psi)
+
+(E ≈ -2.0, x, psi.domain)
+
+# output
+
+(true, [1.0, 0.0], [0.0, 0.5, 1.0])
+```
+
+Hard constraints can impose narrower domain requirements. In particular,
+[`SumConstraint`](@ref) currently requires a nonnegative integer domain.
+
 ## QUBO with Linear and Constant Terms
 
 You can also specify linear and constant terms:

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -81,9 +81,10 @@ Keyword arguments:
   For polynomial objectives, constraints are expressed in the same order as their `effective_variables`.
   If the constraints admit no solution at all, the solve does not error: it logs a warning and
   returns `+Inf` together with an infeasible [`Solution`](@ref) (see [`is_feasible`](@ref)).
-- `domain` - Possible variable values. Defaults to `[0, 1]`;
-  Use `[-1, 1]` for Ising spins or `0:(d - 1)` for a nonnegative integer domain of size `d`.
-  Domains are sorted and deduplicated before solving.
+- `domain` - Possible variable values. Defaults to `[0, 1]`.
+  Unconstrained DMRG optimization accepts any finite collection of real values;
+  individual constraint types can impose narrower requirements. Use `[-1, 1]`
+  for Ising spins. Domains are sorted and deduplicated before solving.
 - `iterations :: Int` - Maximum iterations the solver should run. Defaults to `10`.
 - `cutoff :: Float64` - Any absolute value below this threshold is considered zero. Defaults to `1e-8`.
   You can use this keyword to control the solver's accuracy vs resources trade-off.

--- a/test/fractional_domains.jl
+++ b/test/fractional_domains.jl
@@ -1,0 +1,28 @@
+@testset "Fractional domains" begin
+  @testset "Unconstrained objective" begin
+    domain = [0.0, 0.5, 1.0]
+    l = [-2.0, 3.0]
+
+    E, psi = minimize(l; domain, verbosity=0)
+    x = sample(psi)
+
+    @test E ≈ -2.0
+    @test x == [1.0, 0.0]
+    @test psi.domain == domain
+    @test x in psi
+  end
+
+  @testset "SumConstraint fails fast" begin
+    capacity = SumConstraint([1], [1], 1; relation=:(<=))
+    message = try
+      minimize([0.0]; domain=[0.0, 0.5, 1.0], constraints=[capacity], verbosity=0)
+      ""
+    catch error
+      @test error isa ArgumentError
+      sprint(showerror, error)
+    end
+
+    @test message ==
+      "ArgumentError: SumConstraint only supports nonnegative integer domains."
+  end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ include(filepath("projection_mpo.jl"))
 include(filepath("qubo.jl"))
 include(filepath("pubo.jl"))
 include(filepath("domains.jl"))
+include(filepath("fractional_domains.jl"))
 include(filepath("spin_domains.jl"))
 include(filepath("constrained_solve.jl"))
 


### PR DESCRIPTION
## Summary

- document that unconstrained DMRG accepts finite real-valued domains
- add a runnable fractional-domain doctest with a hand-checked optimum
- add dedicated regression coverage for fractional optimization and the `SumConstraint` fail-fast contract

This is the small documentation/test follow-up requested during review of #109. It does not change runtime behavior.

Refs #109

## Regression evidence

The new fractional-domain testset passes 6/6 against current `main`. As a mutation check, restoring the pre-109 `minimum(alphabet) < 0` guard makes the new constraint assertions fail: fractional input leaks into the partial-sum automaton and raises `InexactError: Int64(0.5)` instead of the documented `ArgumentError`.

## Validation

- `julia +release --project=. -e 'using Pkg; Pkg.test()'`
- `julia +release --project=docs docs/make.jl local`

Both pass locally, including Aqua and doctests.

## Branch hygiene

- base: `main` at `2c67e16b0a0f104851f0f41d9a3b5ab9e712b7dc`
- head: `docs/pr-109-fractional-domain-followup`
- standalone; no prerequisite PRs
- #31 and #44 also touch `docs/src/examples.md`, but only in non-adjacent optional-backend sections; there are no overlapping hunks in this follow-up
