### PR TITLE
tests: speed up redundant solver and projection tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 ITensorMPS = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"
 DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
@@ -18,7 +17,6 @@ TypedPolynomials = "afbbf031-7a57-5f58-a1b9-b774a0fad08d"
 
 [compat]
 Aqua = "0.8.16"
-Documenter = "1.17.0"
 DynamicPolynomials = "0.6.6"
 HDF5 = "0.17.3"
 ITensorMPS = "0.4.1"

--- a/test/backend.jl
+++ b/test/backend.jl
@@ -7,27 +7,22 @@ function TenSolver.minimize(::TestSymbolBackend, Q::AbstractMatrix{T}, l::Union{
 end
 
 @testset "Backend interface" begin
-  @testset "DMRG is the default backend" begin
-    Q = reshape([-2.0], 1, 1)
-
-    default_energy, default_solution = minimize(Q; verbosity=0)
-    object_energy, object_solution = minimize(Q; backend=DMRGBackend(), verbosity=0)
-    symbol_energy, symbol_solution = minimize(Q; backend=:dmrg, verbosity=0)
-
-    @test default_energy ≈ -2.0
-    @test object_energy ≈ default_energy
-    @test symbol_energy ≈ default_energy
-    @test TenSolver.sample(default_solution) == [1]
-    @test TenSolver.sample(object_solution) == [1]
-    @test TenSolver.sample(symbol_solution) == [1]
-  end
-
   @testset "Maximize forwards backend selection" begin
+    # The three-valued domain keeps the diagonal quadratic term in Q instead
+    # of simplifying it into the linear term before it reaches the backend.
     Q = reshape([2.0], 1, 1)
-    E, psi = maximize(Q; backend=:dmrg, verbosity=0)
+    E, payload = maximize(
+      Q;
+      backend=:test_symbol_backend,
+      domain=0:2,
+      verbosity=0,
+    )
 
-    @test E ≈ 2.0
-    @test TenSolver.sample(psi) == [1]
+    @test E == -42.0
+    @test payload.Q == reshape([-2.0], 1, 1)
+    @test payload.l == [0.0]
+    @test payload.c == 0.0
+    @test payload.kwargs[:verbosity] == 0
   end
 
   @testset "Symbol backends can be provided by extensions" begin

--- a/test/constrained_solve.jl
+++ b/test/constrained_solve.jl
@@ -33,11 +33,10 @@ end
     Q = zeros(3, 3)
     l = [-3.0, -2.0, -1.0]
     obj(x) = dot(x, Q, x) + dot(l, x)
-    expected_energy, expected_sample = brute_force(obj, 3, all_constraint_types)
+    expected_energy, expected_sample = -4.0, [1, 0, 1]
 
     E, psi = minimize(Q, l; qubo_kwargs...)
 
-    @test expected_sample == [1, 0, 1]
     assert_constrained_solution(E, psi, obj, all_constraint_types, expected_energy, expected_sample)
   end
 
@@ -49,7 +48,7 @@ end
     ]
     l = [-3.0, -2.0, -1.0]
     obj(x) = dot(x, Q, x) + dot(l, x)
-    expected_energy, expected_sample = brute_force(obj, 3, all_constraint_types)
+    expected_energy, expected_sample = -3.8, [1, 0, 1]
 
     E, psi = minimize(Q, l; preprocess=true, qubo_kwargs...)
 
@@ -83,7 +82,7 @@ end
     DynamicPolynomials.@polyvar y[1:3]
     p = -3.0y[1] - 2.0y[2] - 1.0y[3]
     obj(x) = p(y => x)
-    expected_energy, expected_sample = brute_force(obj, 3, all_constraint_types)
+    expected_energy, expected_sample = -4.0, [1, 0, 1]
 
     E, psi = minimize(
       p;
@@ -256,9 +255,7 @@ end
     capacity = 7
     constraints = AbstractConstraint[SumConstraint([1, 2, 3, 4], weights, capacity; relation=:(<=))]
     obj(x) = -dot(values, x)
-    expected_energy, expected_sample = brute_force(obj, 4, constraints)
-
-    @test expected_sample == [0, 0, 1, 1]
+    expected_energy, expected_sample = -10.0, [0, 0, 1, 1]
 
     E, psi = minimize(
       zeros(4, 4),
@@ -281,9 +278,7 @@ end
     l = [-1.0, 0.5, -3.0, 0.5, -2.0]
     constraints = AbstractConstraint[SumConstraint([1, 3, 5], [1, 1, 1], 1; relation=:(==))]
     obj(x) = dot(l, x)
-    expected_energy, expected_sample = brute_force(obj, 5, constraints)
-
-    @test expected_sample == [0, 0, 1, 0, 0]
+    expected_energy, expected_sample = -3.0, [0, 0, 1, 0, 0]
 
     E, psi = minimize(
       zeros(5, 5),

--- a/test/doctests.jl
+++ b/test/doctests.jl
@@ -1,8 +1,0 @@
-using Test
-using Documenter
-using TenSolver
-
-@testset "Doctests" begin
-    docspath = joinpath(dirname(@__FILE__), "..", "docs", "src")
-    doctest(docspath, [TenSolver])
-end

--- a/test/domains.jl
+++ b/test/domains.jl
@@ -51,7 +51,6 @@ end
      -1.0   3.0  -1.0
       0.0  -1.0   2.0
     ]
-    obj(x) = dot(x, Q, x)
 
     E, psi = minimize(Q; domain = 0:2, iterations = 5, cutoff = 1e-12, verbosity = 0)
 
@@ -61,10 +60,8 @@ end
 
   @testset "Unconstrained linear" begin
     l = [-1.0,  2.0, -3.0]
-    obj(x) = dot(l, x)
 
     E, psi = minimize(l; domain = 0:2, iterations = 5, cutoff = 1e-12, verbosity = 0)
-    E0, x0 = brute_force(obj, 3; domain = 0:2)
 
     @test E ≈ -8
     @test [2, 0, 2] in psi
@@ -77,23 +74,19 @@ end
      -0.5   0.25  1.0
     ]
     l = [-2.0, -1.0, -3.0]
-    obj(x) = dot(x, Q, x) + dot(l, x)
 
     E, psi = minimize(Q, l; domain = 0:2, iterations = 5, cutoff = 1e-12, verbosity = 0)
-    E0, x0 = brute_force(obj, 3; domain = 0:2)
 
-    @test E ≈ E0
-    @test x0 in psi
+    @test E ≈ -4.5
+    @test [1, 0, 2] in psi
   end
 
   @testset "Single site case" begin
     Q = reshape([-2.0], 1, 1)
     l = [3.0]
     c = 5.0
-    obj(x) = dot(x, Q, x) + dot(l, x)
 
     E, psi = minimize(Q, l, c; domain = 0:2, verbosity = 0)
-    E0, x0 = brute_force(obj, 1; domain = 0:2)
 
     @test E ≈ 3.0
     @test [2] in psi
@@ -102,13 +95,12 @@ end
   @testset "Small polynomial case" begin
     DP.@polyvar y[1:3]
     p = y[1]^2 + y[1] * y[2] + 2y[2]^2 - y[2] * y[3] - 3.0y[3]
-    obj(x) = p(y => x)
 
     E, psi = minimize(p; domain = 0:2, iterations = 10, mindim = 5, cutoff = 1e-8, verbosity = 0)
-    E0, x0 = brute_force(obj, 3; domain = 0:2)
 
-    @test E ≈ E0
-    @test x0 in psi
+    @test E ≈ -6.0
+    @test [0, 0, 2] in psi
+    @test sample(psi) in ([0, 0, 2], [0, 1, 2])
   end
 
   @testset "Polynomial exponents are preserved" begin
@@ -132,7 +124,6 @@ end
     constraints = AbstractConstraint[
       SumConstraint([1, 2, 3], [1, 1, 1], 2; relation = :(<=))
     ]
-    obj(x) = dot(x, Q, x) + dot(l, x)
 
     E, psi = minimize(
       Q,
@@ -144,9 +135,10 @@ end
       mindim = 10,
       verbosity = 0,
     )
-    E0, _ = brute_force(obj, 3, constraints; domain = 0:2)
 
-    @test E ≈ E0
+    expected_sample = [1, 0, 0]
+    @test E ≈ -2.0
+    @test expected_sample in psi
     @test is_feasible(sample(psi), constraints)
   end
 

--- a/test/jump.jl
+++ b/test/jump.jl
@@ -1,43 +1,21 @@
 import JuMP
 
-@testset "JuMP interface" begin
-  dim = 5
-  Q = 2*randn(dim, dim)
-  l = 2*randn(dim)
-  c = randn()
-  obj(x) = dot(x, Q, x) + dot(l, x) + c
-
-  m = JuMP.Model(TenSolver.Optimizer)
-  @JuMP.variable(m, x[1:dim], Bin)
-  @JuMP.objective(m, Min, dot(x, Q, x) + dot(l, x) + c)
-
-  JuMP.optimize!(m)
-
-  e = JuMP.objective_value(m)
-
-  # ~:~ Exact solution ~:~ #
-  e0, x0 = brute_force(obj, dim)
-  # Same minimum value
-  @test e ≈ e0
-  # Same solution
-  @test JuMP.value.(x) == x0
-end
-
-@testset "JuMP preprocess attribute" begin
+@testset "JuMP interface and preprocess attribute" begin
   Q = [0.0 0.0 -2.0;
        0.0 0.0  0.0;
       -2.0 0.0  0.0]
   l = [0.5, 1.0, 0.5]
+  c = 1.25
 
   m = JuMP.Model(TenSolver.Optimizer)
   JuMP.set_silent(m)
   JuMP.set_attribute(m, "preprocess", true)
   JuMP.set_attribute(m, "iterations", 3)
   @JuMP.variable(m, x[1:3], Bin)
-  @JuMP.objective(m, Min, dot(x, Q, x) + dot(l, x))
+  @JuMP.objective(m, Min, dot(x, Q, x) + dot(l, x) + c)
 
   JuMP.optimize!(m)
 
-  @test JuMP.objective_value(m) ≈ -3.0
+  @test JuMP.objective_value(m) ≈ -1.75
   @test JuMP.value.(x) == [1, 0, 1]
 end

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -21,6 +21,17 @@ function assert_projection_matches_feasibility(constraint, sites; domain = 0:1)
   return H
 end
 
+function assert_projection_spot_checks(constraint, sites; domain = 0:1)
+  H = TenSolver.projection_mpo(constraint, sites; domain)
+
+  for _ in 1:2
+    bits = rand(domain, length(sites))
+    @test mpo_diagonal(H, sites, bits) ≈ is_feasible(bits, constraint) atol=sqrt(eps(Float64))
+  end
+
+  return H
+end
+
 function dfa_accepts(dfa, input)
   state = dfa.initial
 
@@ -134,11 +145,20 @@ end
     end
   end
 
-  @testset "Projection MPO" begin
+  @testset "Projection MPO spot checks" begin
     sites = ITensors.siteinds("Qudit", 4; dim=2)
 
-    for constraint in TEST_CONSTRAINTS
-      assert_projection_matches_feasibility(constraint, sites)
+    cases = [
+      SumConstraint([1, 3], [2, 1], :(<=), 2),
+      NotEqualsConstraint([1, 3], [1, 0]),
+      NotEqualsConstraint([1, 2], [1.0, 0.0]),
+      NotEqualsConstraint([1, 3, 2, 4], Bool[1, 0, 0, 1]),
+      AssignmentConstraint([1, 3], [1], :(==), 1),
+      RelationConstraint(4, :(<=), 2),
+    ]
+
+    for constraint in cases
+      assert_projection_spot_checks(constraint, sites)
     end
   end
 
@@ -171,14 +191,25 @@ end
     @test all(isempty, ITensorMPS.siteinds(all, H_eff; plev=2))
     @test ITensorMPS.siteinds(projected_psi) == sites
 
-    for bra_bits in all_bitstrings(sites), ket_bits in all_bitstrings(sites)
-      bra_feasible = is_feasible(collect(bra_bits), constraints)
-      ket_feasible = is_feasible(collect(ket_bits), constraints)
-      expected = bra_feasible && ket_feasible ?
-        mpo_matrix_element(H, sites, bra_bits, ket_bits) :
+    for bits in all_bitstrings(sites)
+      feasible = is_feasible(collect(bits), constraints)
+      expected = feasible ?
+        mpo_diagonal(H, sites, bits) :
         0.0
 
-      @test mpo_matrix_element(H_eff, sites, bra_bits, ket_bits) ≈ expected atol=1e-10
+      @test mpo_diagonal(H_eff, sites, bits) ≈ expected atol=1e-10
+    end
+
+    # Both the objective and projections are diagonal. Representative
+    # off-diagonal checks guard against index/prime mistakes without repeating
+    # the same zero contraction for every pair of basis states.
+    for (bra_bits, ket_bits) in (
+      ((0, 0, 0), (1, 0, 0)),
+      ((0, 0, 1), (0, 1, 1)),
+      ((0, 0, 0), (0, 0, 1)),
+      ((0, 0, 0), (1, 1, 0)),
+    )
+      @test mpo_matrix_element(H_eff, sites, bra_bits, ket_bits) ≈ 0.0 atol=1e-10
     end
 
     for bits in all_bitstrings(sites)
@@ -219,8 +250,15 @@ end
 
     @test length(Hs) == length(constraints)
 
+    # Across these assignments every constraint sees both an accepted and a
+    # rejected case after the nontrivial tensor-to-original permutation.
+    samples = (
+      (0, 0, 0, 0, 0),
+      (1, 0, 1, 0, 1),
+      (0, 1, 1, 1, 0),
+    )
     for (constraint, H) in zip(constraints, Hs)
-      for bits in all_bitstrings(sites)
+      for bits in samples
         original_bits = collect(bits)[invperm(perm)]
         expected = Float64(is_feasible(original_bits, constraint))
         @test mpo_diagonal(H, sites, bits) ≈ expected atol=1e-8
@@ -238,20 +276,15 @@ end
     psi = ITensorMPS.MPS(sites, fill("full", length(sites)))
     projected_psi = TenSolver.project_state(psi, P; cutoff=1e-12)
 
-    for bra_bits in all_bitstrings(sites), ket_bits in all_bitstrings(sites)
-      @test mpo_matrix_element(H_eff, sites, bra_bits, ket_bits) == 0.0
-    end
-
-    for bits in all_bitstrings(sites)
-      @test mps_amplitude(projected_psi, sites, bits) ≈ 0.0 atol=1e-8
-    end
+    @test norm(H_eff) ≈ 0.0 atol=1e-12
+    @test norm(projected_psi) ≈ 0.0 atol=1e-12
   end
 
   @testset "NotEqualsConstraint projection" begin
     sites = ITensors.siteinds("Qudit", 4; dim=2)
 
     forbidden_tuple = NotEqualsConstraint([1, 3, 4], [1, 0, 1])
-    H = assert_projection_matches_feasibility(forbidden_tuple, sites)
+    H = TenSolver.projection_mpo(forbidden_tuple, sites; domain = 0:1)
 
     for bits in all_bitstrings(sites)
       forbidden = bits[1] == 1 && bits[3] == 0 && bits[4] == 1
@@ -346,7 +379,7 @@ end
         @test dfa_accepts(dfa, bits) == is_feasible(collect(bits), constraint)
       end
 
-      H = assert_projection_matches_feasibility(constraint, sites)
+      H = TenSolver.projection_mpo(constraint, sites; domain = 0:1)
       @test ITensorMPS.maxlinkdim(H) <= 2
     end
   end
@@ -373,19 +406,13 @@ end
       SumConstraint([2, 3], [2.0, 3.0], 3.0; relation=:(>=)),
       SumConstraint([1, 2], [1.0, 2.0], 1.0; relation=:(!=)),
     ]
-
     for constraint in constraints
       dfa = TenSolver.constraint_to_dfa(constraint, length(sites), 0:1)
-      H = TenSolver.projection_mpo(constraint, sites; domain = 0:1)
+      assert_projection_spot_checks(constraint, sites)
 
       for bits in all_bitstrings(sites)
         expected = is_feasible(collect(bits), constraint)
         @test dfa_accepts(dfa, bits) == expected
-      end
-
-      for bits in all_bitstrings(sites)
-        expected = Float64(is_feasible(collect(bits), constraint))
-        @test mpo_diagonal(H, sites, bits) ≈ expected atol=1e-8
       end
     end
 

--- a/test/pubo.jl
+++ b/test/pubo.jl
@@ -1,58 +1,35 @@
 import DynamicPolynomials as DP
 import TypedPolynomials   as TP
-import MultivariatePolynomials: maxdegree, effective_variables
+import MultivariatePolynomials: maxdegree
 
-function test_correctness(dim, obj, args...)
+function test_correctness(obj, expected_energy, expected_sample, args...)
     # TenSolver solution
     e, psi = TenSolver.minimize(args...; verbosity = 0)
     x = TenSolver.sample(psi)
 
     # Does the ground energy match solution?
     @test obj(x) ≈ e
-
-    for _ in 1:10
-      y = rand(Bool, dim)
-      @test obj(y) >= e - 1e-8 # A small gap to amount for floating errors
-    end
-
-    # ~:~ Exact solution ~:~ #
-    e0, x0 = brute_force(obj, dim)
-    # Same minimum value
-    @test e ≈ e0
-    # Solution is sampleable
-    @test x0 in psi
+    @test e ≈ expected_energy
+    @test x == expected_sample
+    @test expected_sample in psi
 end
 
 @testset "DynamicPolynomials.jl" begin
-  dim = 5
-  DP.@polyvar x[1:dim]
+  DP.@polyvar x[1:3]
+  # One fixed mixed-degree objective exercises linear, quadratic, and cubic
+  # lowering. The cubic term changes the unique optimum from [1, 1, 1].
+  p = 1.5 - 3x[1] - 2x[2] - x[3] + 0.5x[1] * x[2] +
+      5x[1] * x[2] * x[3]
 
-  @testset "Quadratic" begin
-    p = randpoly(x, 2)
-    @test maxdegree(p) == 2
-    test_correctness(dim, a -> p(x => a), p)
-  end
-
-  @testset "Cubic" begin
-    p = randpoly(x, 3)
-    @test maxdegree(p) == 3
-    test_correctness(dim, a -> p(x => a), p)
-  end
+  @test maxdegree(p) == 3
+  test_correctness(a -> p(x => a), -3.0, [1, 1, 0], p)
 end
 
 @testset "TypedPolynomials.jl" begin
-  dim = 5
-  TP.@polyvar x[1:5]
+  TP.@polyvar x[1:3]
+  p = 1.5 - 3x[1] - 2x[2] - x[3] + 0.5x[1] * x[2] +
+      5x[1] * x[2] * x[3]
 
-  @testset "Quadratic" begin
-    p = randpoly(x, 2)
-    @test maxdegree(p) == 2
-    test_correctness(dim, a -> p(x => a), p)
-  end
-
-  @testset "Cubic" begin
-    p = randpoly(x, 3)
-    @test maxdegree(p) == 3
-    test_correctness(dim, a -> p(x => a), p)
-  end
+  @test maxdegree(p) == 3
+  test_correctness(a -> p(x => a), -3.0, [1, 1, 0], p)
 end

--- a/test/qubo.jl
+++ b/test/qubo.jl
@@ -54,7 +54,7 @@
 
     @testset "Single variable" begin
       Q = reshape([-2.0], 1, 1)
-      E, psi = minimize(Q; verbosity = 0)
+      E, psi = minimize(Q; backend = :dmrg, verbosity = 0)
 
       @test E ≈ -2.0
       @test TenSolver.sample(psi) == [1]
@@ -239,7 +239,15 @@
   end
 
   @testset "Pure quadratic" begin
-    Q = randn(dim, dim)
+    Q = [
+       0.0  1.0  0.0  0.0 -0.5
+       0.0  0.0  0.75 0.0  0.0
+       0.0  0.0  0.0 -1.0  0.0
+       0.0  0.0  0.0  0.0  0.5
+       0.0  0.0  0.0  0.0  0.0
+    ]
+    l = [-2.0, 1.0, -3.0, 2.0, -1.0]
+    Q = Q + Diagonal(l)
 
     # TenSolver solution
     e, psi = TenSolver.minimize(Q; verbosity = 0)
@@ -250,27 +258,21 @@
 
     # Does the ground energy match the solution?
     @test dot(x, Q, x) ≈ e
-
-    for i in 1:10
-      y = rand(Bool, dim)
-      @test dot(y, Q, y) >= e - 1e-8 # A small gap to amount for floating errors
-    end
-
-    # ~:~ Exact solution ~:~ #
-
-    e0, x0 = brute_force(x -> dot(x, Q, x), dim)
-    # Same minimum value
-    @test e ≈ e0
-    # Same solution
-    @test x == x0
-    # Ground state
-    @test x0 in psi
+    @test e ≈ -6.5
+    @test x == [1, 0, 1, 0, 1]
+    @test [1, 0, 1, 0, 1] in psi
   end
 
   @testset "Quad+Lin" begin
-    Q = 2*randn(dim, dim)
-    l = 2*randn(dim)
-    c = randn()
+    Q = [
+      0.0  0.5   0.0   0.0  0.0
+      0.5  0.0  -0.25  0.0  0.0
+      0.0 -0.25  0.0   0.75 0.0
+      0.0  0.0   0.75  0.0 -0.5
+      0.0  0.0   0.0  -0.5  0.0
+    ]
+    l = [1.0, -2.0, 0.5, -3.0, 1.5]
+    c = 1.25
 
     # Objective function
     obj(x) = dot(x, Q, x) + dot(l, x) + c
@@ -281,17 +283,8 @@
 
     # Does the ground energy match solution?
     @test obj(x) ≈ e
-
-    for i in 1:10
-      y = rand(Bool, dim)
-      @test obj(y) >= e - 1e-8 # A small gap to amount for floating errors
-    end
-
-    # ~:~ Exact solution ~:~ #
-    e0, x0 = brute_force(obj, dim)
-    # Same minimum value
-    @test e ≈ e0
-    # Solution is sampleable
-    @test x0 in psi
+    @test e ≈ -3.75
+    @test x == [0, 1, 0, 1, 0]
+    @test [0, 1, 0, 1, 0] in psi
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,3 @@ include(filepath("hdf5.jl"))
 
 # QUBODrivers.jl and Aqua.jl test suites
 include(filepath("external.jl"))
-
-# Documentation tests
-include(filepath("doctests.jl"))

--- a/test/spin_domains.jl
+++ b/test/spin_domains.jl
@@ -11,7 +11,6 @@ import DynamicPolynomials
     ]
     h = [0.25, -1.5, 0.75]
     offset = 2.0
-    obj(s) = dot(s, J, s) + dot(h, s) + offset
 
     E, psi = minimize(
       J,
@@ -23,10 +22,9 @@ import DynamicPolynomials
       cutoff = 1e-12,
       verbosity = 0,
     )
-    E0, s0 = brute_force(obj, 3; domain = spin_domain)
 
-    @test E ≈ E0
-    @test s0 in psi
+    @test E ≈ 0.5
+    @test [1, 1, -1] in psi
     @test all(in(spin_domain), sample(psi))
   end
 
@@ -47,7 +45,6 @@ import DynamicPolynomials
   @testset "Polynomial objective" begin
     DynamicPolynomials.@polyvar s[1:3]
     p = 1.5s[1] * s[2] - 2.0s[2] * s[3] + 0.5s[1]^2 + s[3]
-    obj(x) = real(p(s => x))
 
     E, psi = minimize(
       p;
@@ -57,10 +54,9 @@ import DynamicPolynomials
       cutoff = 1e-12,
       verbosity = 0,
     )
-    E0, s0 = brute_force(obj, 3; domain = spin_domain)
 
-    @test E ≈ E0
-    @test s0 in psi
+    @test E ≈ -4.0
+    @test [1, -1, -1] in psi
   end
 
   @testset "Constraints use physical Spin values" begin
@@ -74,7 +70,6 @@ import DynamicPolynomials
       NotEqualsConstraint([1, 2], [1, 1]),
       RelationConstraint(1, :(!=), 3),
     ]
-    obj(s) = dot(s, J, s) + dot(h, s)
 
     E, psi = minimize(
       J,
@@ -87,11 +82,11 @@ import DynamicPolynomials
       cutoff = 1e-12,
       verbosity = 0,
     )
-    E0, s0 = brute_force(obj, 3, constraints; domain = spin_domain)
+    expected_sample = [1, -1, -1]
     sampled = sample(psi)
 
-    @test E ≈ E0
-    @test s0 in psi
+    @test E ≈ -2.0
+    @test expected_sample in psi
     @test psi.permutation != collect(1:3)
     @test is_feasible(sampled, constraints)
     @test all(in(spin_domain), sampled)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -6,8 +6,9 @@
 """
     brute_force(f, n[, constraints]; domain = 0:1)
 
-A QUBO solver using a brute force approach instead of Tensor networks.
-Despite being painfully slow, this is useful as a sanity check.
+Return the minimum objective value and one minimizer found by exhaustive
+enumeration. Use only for small test problems because the work grows as
+`length(domain)^n`.
 """
 function brute_force(obj, n, constraints = AbstractConstraint[]; domain = 0:1)
   best = +Inf


### PR DESCRIPTION
## Summary

- make the Documentation workflow the sole doctest owner and remove Documenter from the package test environment
- replace `brute_force`-derived solver expectations with fixed, independently calculated energies while retaining the helper as a documented small-problem utility
- keep `test/backend.jl` exclusively about backend-interface infrastructure; cover public `backend = :dmrg` selection through an existing QUBO solver test without adding a solve
- separate direct randomized property checks from cheap explicit/exhaustive unit cases, relying on `@testset`'s default-RNG handling
- preserve both known-optimum membership and sampled-result validity where they exercise distinct completeness and soundness contracts
- consolidate overlapping QUBO, PUBO, JuMP, domain, and constrained-solver work
- keep constraint semantics exhaustive at the DFA/direct-MPO layers while reducing repeated expensive projection assertions
- leave the 3×3 Julia CI matrix unchanged, following Iago's guidance on #102 to focus this pass on testset redundancy rather than runner parallelism

The final diff against current `main` is test-only: 12 files, 136 insertions, and 196 deletions.

## Current-base runtime and coverage

One matched warm local Julia 1.10.11 full-suite sample on exact current base `3037824` and exact head `6b25f0a`:

| Metric | `main` (`3037824`) | PR (`6b25f0a`) | Change |
|---|---:|---:|---:|
| Full-suite wall time | 194.3s | 179.7s | **-14.7s (-7.5%)** |
| Projection assertions | 2,612 | 1,723 | -889 (-34.0%) |
| Projection testset time | 42.5s | 53.2s | +10.7s; no speedup |
| Executable source lines covered | 702/741 (94.737%) | 702/741 (94.737%) | identical line identities |

The projection assertion reduction still does **not** make that testset faster: expensive MPO construction and contraction dominate it, and the observed timing is noisy. The full-suite sample is 7.5% faster because this PR removes other redundant work, notably a concrete backend solve and package-suite doctest ownership. The Documentation workflow remains the doctest owner.

## Verification

- exact-head full Julia 1.10 suite passed, with 3 expected broken tests
- focused QUBO testset on exact head: 88/88 passed
- focused projection testset on exact head: 1,723/1,723 passed
- source coverage: no base-only or candidate-only executable/covered line identities
- local docs workflow, including doctests: passed after the documented dependency-install step
- `git diff --check origin/main...HEAD`
- conflict-free merge-tree against current `main`

Exact-head hosted CI is green: Documentation and all nine Julia matrix lanes passed. On attempt 1, Julia 1/Windows completed every package testset and then hit Aqua's external persistent-task missing-`done.log` error; Julia pre/Windows was canceled by fail-fast. Both Windows lanes passed on the single bounded rerun (attempt 2).

## Review and branch hygiene

- merged current `main` append-only in `9f9381f`
- addressed Iago's latest inline review in `4985059`: backend tests are interface-only, explicit RNG handling is gone, randomized property checks are direct and branch-free, and the retained utility's docstring contains only stable behavior/usage
- addressed Iago's follow-up discussion by preserving both deterministic known-optimum membership and sampled-result validity checks
- restored symbolic DMRG-selection coverage outside the backend-interface file in `6b25f0a`, reusing an existing solver call; exact source coverage remains identical to `main`
- Iago approved exact head `6b25f0a`; GitHub currently reports `reviewDecision=APPROVED` and `mergeStateStatus=CLEAN`

## Scope

Refs #102.

This remains a P1 redundancy slice and does not auto-close #102. Test-group lanes, quality-gate/coverage placement, nightly coverage, and timing observability remain follow-up work.

## Post-approval linearization

This repository allows only rebase merges, and GitHub could not rebase the reviewed branch because it contained two conflict-resolving merges of `main`. The branch was therefore linearized to the single commit `dbe6d9c` on top of `main` = `3037824`, with a tree byte-identical to the approved head `6b25f0a` (verified: empty `git diff` between the two; the diff against `main` is unchanged at 12 files, +136/-196). Iago's approval refers to `6b25f0a`; the content is unchanged.

