### PR TITLE
Expose operator bond dims in solutions

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -21,6 +21,7 @@ TenSolver.normalize_backend
 
 ```@docs
 TenSolver.Solution
+TenSolver.SolverStatistics
 ```
 
 ## Sampling Functions

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -239,18 +239,9 @@ x = TenSolver.sample(psi)
 
 ## Tracking Optimization Progress
 
-The returned `Solution` always carries lightweight per-iteration stats:
+The returned `Solution` always carries lightweight per-iteration statistics in the `stats` field.
+See [`TenSolver.SolverStatistics`](@ref) for more details.
 
-```julia
-using TenSolver
-
-Q = randn(40, 40)
-E, psi = TenSolver.minimize(Q; iterations=50)
-
-psi.energies       # objective value at each iteration
-psi.bond_dims      # MPS bond dimension at each iteration
-psi.elapsed_times  # wall-clock time at each iteration
-```
 
 For per-iteration sampling, pass an `on_iteration` callback.
 The callback receives the MPS for that iteration alongside metadata as keyword arguments.

--- a/src/TenSolver.jl
+++ b/src/TenSolver.jl
@@ -137,7 +137,7 @@ function tensolver_metadata(
   vtol::Real,
   maxdim,
 )
-  optimizer_iterations = length(solution.energies)
+  optimizer_iterations = length(solution.stats.energies)
   termination_status, status = tensolver_status(
     solution;
     iterations,
@@ -159,8 +159,8 @@ function tensolver_metadata(
   metadata["time"] = Dict{String,Any}("effective" => effective_time)
   metadata["tensolver"] = Dict{String,Any}(
     "dmrg" => Dict{String,Any}(
-      "sweep_elapsed" => copy(solution.elapsed_times),
-      "sweep_times"   => sweep_times(solution.elapsed_times),
+      "sweep_elapsed" => copy(solution.stats.elapsed_times),
+      "sweep_times"   => sweep_times(solution.stats.elapsed_times),
     ),
     "parameters" => Dict{String,Any}(
       "cutoff"     => cutoff,
@@ -175,10 +175,10 @@ function tensolver_metadata(
 end
 
 function tensolver_status(solution::Solution; iterations::Integer, time_limit::Real)
-  elapsed_time = isempty(solution.elapsed_times) ? 0.0 : last(solution.elapsed_times)
+  elapsed_time = isempty(solution.stats.elapsed_times) ? 0.0 : last(solution.stats.elapsed_times)
   if !is_feasible(solution)
     return MOI.INFEASIBLE, "infeasible"
-  elseif length(solution.energies) >= iterations
+  elseif length(solution.stats.energies) >= iterations
     return MOI.ITERATION_LIMIT, "iteration_limit"
   elseif isfinite(time_limit) && elapsed_time > time_limit
     return MOI.TIME_LIMIT, "time_limit"

--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -91,11 +91,11 @@ function minimize(
   cutoff=1e-8,
   domain::AbstractVector = 0:1,
   kwargs...,
-) where T
-  H      = tensorize(p; cutoff, domain)
+) where {T}
   cte    = constant_term(p)
   vs     = effective_variables(p)
   obj(x) = real(p(vs => x))
+  H      = tensorize(p; cutoff, domain)
 
   return minimize_mpo(H, cte, obj ; cutoff, domain, kwargs...)
 end
@@ -143,10 +143,10 @@ end
 # Infeasibility is a solver outcome, not an argument error: report it as a
 # status like other optimization packages (objective +Inf, empty Solution),
 # so it maps onto MOI.INFEASIBLE at the JuMP layer. See the discussion in #94.
-function infeasible_result(::Type{T}, domain) where {T}
+function infeasible_result(::Type{T}, domain, stats) where {T}
   @warn "constraints define an empty feasible subspace"
   F = float(T)
-  return real(T)(+Inf), infeasible_solution(F, domain)
+  return real(T)(+Inf), infeasible_solution(F, domain, stats)
 end
 
 
@@ -249,7 +249,7 @@ function minimize_mpo( H_obj :: MPO
                      # Iteration callback
                      , on_iteration     :: Union{Nothing, Function} = nothing
                      , callback_every   :: Int = 1
-                     , permutation :: Vector{Int} = collect(1:length(H))
+                     , permutation :: Vector{Int} = collect(1:length(H_obj))
                      ) where {T}
   callback_every >= 1 || throw(ArgumentError("`callback_every` must be >= 1, got $callback_every"))
   initial_time      = time()
@@ -272,15 +272,12 @@ function minimize_mpo( H_obj :: MPO
 
   # Initial state
   psi = constrained_initial_state(T, sites, projections; cutoff, inidim)
-  if isnothing(psi)
-    return infeasible_result(T, domain)
-  end
   psi = device(psi)
 
-  bond_stats = (;
+  stats = SolverStatistics{T}(;
     projections   = ITensorMPS.maxlinkdim.(projections),
     objective     = ITensorMPS.maxlinkdim(H_obj),
-    initial_state = ITensorMPS.maxlinkdim(psi),
+    initial_state = isnothing(psi) ? 0 : ITensorMPS.maxlinkdim(psi),
     hamiltonian   = ITensorMPS.maxlinkdim(H),
   )
 
@@ -296,7 +293,9 @@ function minimize_mpo( H_obj :: MPO
   var    = T(Inf)
   energy = T(Inf)
 
-  for i in Iterators.countfrom(1)
+  iter = isnothing(psi) ? [] : Iterators.countfrom(1)
+
+  for i in iter
     energy, psi = groundstate(H, device(psi)
                       ; projections
                       , nsweeps     = 1
@@ -323,6 +322,9 @@ function minimize_mpo( H_obj :: MPO
 
     bond_dim = ITensorMPS.maxlinkdim(psi)
 
+    # Per-iteration stats (always collected)
+    record_stats!(stats, i; energy = energy+c, bond_dim, elapsed_time)
+
     iterlog_iteration(
       verbosity,
       i,
@@ -331,11 +333,6 @@ function minimize_mpo( H_obj :: MPO
       i % check_variance_every_iteration == 0 ? var : nothing,
       elapsed_time,
     )
-
-    # Per-iteration stats (always collected)
-    push!(energies_log,      energy + c)
-    push!(bond_dims_log,     bond_dim)
-    push!(elapsed_times_log, elapsed_time)
 
     # Optional callback
     if !isnothing(on_iteration) && i % callback_every == 0
@@ -358,13 +355,12 @@ function minimize_mpo( H_obj :: MPO
     end
   end
 
-
   if isinf(energy)
-    optimal, dist = infeasible_result(T, domain)
+    optimal, dist = infeasible_result(T, domain, stats)
   else
     # The calculated energy has approximation errors compared to the true solution.
     # It makes more sense to sample a solution and calculate the true objective function applied to it.
-    dist = Solution{T}(psi, domain, permutation, energies_log, bond_dims_log, elapsed_times_log, bond_stats)
+    dist = Solution{T}(psi, domain, permutation, stats)
     optimal = obj(sample(dist))
   end
 

--- a/src/backends/dmrg.jl
+++ b/src/backends/dmrg.jl
@@ -225,8 +225,8 @@ function tensorize(
   return isempty(os) ? MPO(T,sites) : MPO(T, os, sites)
 end
 
-function minimize_mpo( H :: MPO
-                     , c :: T
+function minimize_mpo( H_obj :: MPO
+                     , c     :: T
                      , obj
                      ; device      = cpu
                      , cutoff      = 1e-8  #  a cutoff of 1E-5 gives sensible accuracy; a cutoff of 1E-8 is high accuracy; and a cutoff of 1E-12 is near exact accuracy. (https://itensor.org/docs.cgi?page=tutorials/dmrg_params)
@@ -258,7 +258,7 @@ function minimize_mpo( H :: MPO
   elapsed_times_log = Float64[]
 
   # Quantization
-  sites = ITensorMPS.siteinds(first, H; plev=0)
+  sites = ITensorMPS.siteinds(first, H_obj; plev=0)
 
   # Constraints
   projections = map(
@@ -267,8 +267,8 @@ function minimize_mpo( H :: MPO
   )
 
   # Hamiltonian construction
-  H = device(H)
-  H = is_zero_tensor(H; cutoff) ? H : project_hamiltonian(H, projections; cutoff)
+  H_obj = device(H_obj)
+  H = is_zero_tensor(H_obj; cutoff) ? H_obj : device(project_hamiltonian(H_obj, projections; cutoff))
 
   # Initial state
   psi = constrained_initial_state(T, sites, projections; cutoff, inidim)
@@ -276,6 +276,13 @@ function minimize_mpo( H :: MPO
     return infeasible_result(T, domain)
   end
   psi = device(psi)
+
+  bond_stats = (;
+    projections   = ITensorMPS.maxlinkdim.(projections),
+    objective     = ITensorMPS.maxlinkdim(H_obj),
+    initial_state = ITensorMPS.maxlinkdim(psi),
+    hamiltonian   = ITensorMPS.maxlinkdim(H),
+  )
 
   @debug(
     "Constraint projection MPO construction finished",
@@ -332,7 +339,7 @@ function minimize_mpo( H :: MPO
 
     # Optional callback
     if !isnothing(on_iteration) && i % callback_every == 0
-      on_iteration(psi; iteration=i, objective=energy+c, bond_dim, elapsed_time)
+      on_iteration(psi; iteration=i, objective=energy+c, bond_dim, elapsed_time, variance = var)
     end
 
     # Stopping criteria #
@@ -357,7 +364,7 @@ function minimize_mpo( H :: MPO
   else
     # The calculated energy has approximation errors compared to the true solution.
     # It makes more sense to sample a solution and calculate the true objective function applied to it.
-    dist = Solution{T}(psi, domain, permutation, energies_log, bond_dims_log, elapsed_times_log)
+    dist = Solution{T}(psi, domain, permutation, energies_log, bond_dims_log, elapsed_times_log, bond_stats)
     optimal = obj(sample(dist))
   end
 

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -14,38 +14,52 @@ Use [`sample`](@ref) to draw vectors from it.
 - `tensor`: the underlying MPS, or `nothing` when the model is infeasible.
 - `domain`: possible variable values.
 - `permutation`: original variable index represented by each tensor site.
-- `energies`: expected objective value of the problem recorded at each iteration of the solver.
-- `bond_dims`: maximum MPS bond dimension at each iteration.
-- `elapsed_times`: wall-clock time in seconds from the start of the solve at each iteration.
+- `stats`: per-iteration convergence stats, with fields:
+  - `energies`: expected objective value of the problem recorded at each iteration of the solver.
+  - `bond_dims`: maximum MPS bond dimension at each iteration.
+  - `elapsed_times`: wall-clock time in seconds from the start of the solve at each iteration.
 
-The three stats vectors are parallel — `energies[i]`, `bond_dims[i]`, and `elapsed_times[i]`
+
+The stats vectors are parallel:
+`stats.energies[i]`, `stats.bond_dims[i]`, and `stats.elapsed_times[i]`
 all correspond to iteration `i`.
 
 Provably infeasible models produce a `Solution` with no MPS and empty stats
 vectors; check with [`is_feasible`](@ref) before sampling.
 """
 struct Solution{T <: Real}
-    tensor        :: Union{MPS, Nothing}
-    domain        :: Vector{T}
-    permutation   :: Vector{Int}
-    energies      :: Vector{T}
-    bond_dims     :: Vector{Int}
-    elapsed_times :: Vector{Float64}
+  tensor      :: Union{MPS, Nothing}
+  domain      :: Vector{T}
+  permutation :: Vector{Int}
+  stats       :: NamedTuple{
+    (:energies, :bond_dims, :elapsed_times, :max_bonds),
+    Tuple{
+      Vector{T},
+      Vector{Int},
+      Vector{Float64},
+      NamedTuple{
+        (:projections, :objective, :initial_state, :hamiltonian),
+        Tuple{Vector{Int}, Int, Int, Int},
+      },
+    },
+  }
 
-    function Solution{T}(
-      tensor::Union{MPS,Nothing},
-      domain,
-      permutation::Vector{Int},
-      energies::Vector{T},
-      bond_dims::Vector{Int},
-      elapsed_times::Vector{Float64},
-    ) where {T <: Real}
-      return new{T}(tensor, domain, permutation, energies, bond_dims, elapsed_times)
-    end
+  function Solution{T}(
+    tensor::Union{MPS,Nothing},
+    domain,
+    permutation::Vector{Int},
+    energies::Vector{T},
+    bond_dims::Vector{Int},
+    elapsed_times::Vector{Float64},
+    max_bonds,
+  ) where {T <: Real}
+    stats = (; energies, bond_dims, elapsed_times, max_bonds)
+    return new{T}(tensor, domain, permutation, stats)
+  end
 end
 
 function infeasible_solution(::Type{T}, domain) where {T <: Real}
-  return Solution{T}(nothing, domain, Int[], T[], Int[], Float64[])
+  return Solution{T}(nothing, domain, Int[], T[], Int[], Float64[], (; projections = [], objective = 0, initial_state = 0, hamiltonian = 0))
 end
 
 """

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -2,7 +2,46 @@ import ITensors, ITensorMPS
 import ITensorMPS: MPS, siteinds
 
 """
-    Solution
+    SolverStatistics{T}
+
+## Fields
+
+- `energies`: per-iteration calculated energy/objective value;
+- `bond_dims`: per-iteration solution maximum bond dimension;
+- `elapsed_times`: per-iteration total until the iteration completed;
+- `max_bonds`: structure containing bond dimensions for multiple tensors used throughout the iteration
+  - `initial_state`: bond for the initial MPS guess;
+  - `objective`: bond for the MPO representing the objective function `H`;
+  - `projections`: bonds for the MPOs representing each constraint;
+  - `hamiltonian`: bond for the MPO representing the actual Hamiltonian `P'HP` representing both objective and constraints;
+"""
+struct SolverStatistics{T <: Real}
+  energies      :: Vector{T}
+  bond_dims     :: Vector{Int64}
+  elapsed_times :: Vector{Float64}
+  max_bonds     :: @NamedTuple begin
+    projections   :: Vector{Int64}
+    objective     :: Int64
+    initial_state :: Int64
+    hamiltonian   :: Int64
+  end
+
+  function SolverStatistics{T}(; projections, objective, initial_state, hamiltonian) where {T}
+    new{T}(T[], Int64[], Float64[], (; projections, objective, initial_state, hamiltonian))
+  end
+end
+
+function record_stats!(stats::SolverStatistics, _i::Integer; energy, bond_dim, elapsed_time)
+    push!(stats.energies,      energy)
+    push!(stats.bond_dims,     bond_dim)
+    push!(stats.elapsed_times, elapsed_time)
+
+    return stats
+end
+
+
+"""
+    Solution{T}
 
 The result of running [`minimize`](@ref) or [`maximize`](@ref): an MPS wave function
 over the optimal solution space, together with per-iteration convergence stats.
@@ -14,15 +53,7 @@ Use [`sample`](@ref) to draw vectors from it.
 - `tensor`: the underlying MPS, or `nothing` when the model is infeasible.
 - `domain`: possible variable values.
 - `permutation`: original variable index represented by each tensor site.
-- `stats`: per-iteration convergence stats, with fields:
-  - `energies`: expected objective value of the problem recorded at each iteration of the solver.
-  - `bond_dims`: maximum MPS bond dimension at each iteration.
-  - `elapsed_times`: wall-clock time in seconds from the start of the solve at each iteration.
-
-
-The stats vectors are parallel:
-`stats.energies[i]`, `stats.bond_dims[i]`, and `stats.elapsed_times[i]`
-all correspond to iteration `i`.
+- `stats`: per-iteration convergence stats. See [`SolverStatistics`](@ref).
 
 Provably infeasible models produce a `Solution` with no MPS and empty stats
 vectors; check with [`is_feasible`](@ref) before sampling.
@@ -31,35 +62,20 @@ struct Solution{T <: Real}
   tensor      :: Union{MPS, Nothing}
   domain      :: Vector{T}
   permutation :: Vector{Int}
-  stats       :: NamedTuple{
-    (:energies, :bond_dims, :elapsed_times, :max_bonds),
-    Tuple{
-      Vector{T},
-      Vector{Int},
-      Vector{Float64},
-      NamedTuple{
-        (:projections, :objective, :initial_state, :hamiltonian),
-        Tuple{Vector{Int}, Int, Int, Int},
-      },
-    },
-  }
+  stats       :: SolverStatistics{T}
 
   function Solution{T}(
     tensor::Union{MPS,Nothing},
     domain,
     permutation::Vector{Int},
-    energies::Vector{T},
-    bond_dims::Vector{Int},
-    elapsed_times::Vector{Float64},
-    max_bonds,
+    stats::SolverStatistics,
   ) where {T <: Real}
-    stats = (; energies, bond_dims, elapsed_times, max_bonds)
     return new{T}(tensor, domain, permutation, stats)
   end
 end
 
-function infeasible_solution(::Type{T}, domain) where {T <: Real}
-  return Solution{T}(nothing, domain, Int[], T[], Int[], Float64[], (; projections = [], objective = 0, initial_state = 0, hamiltonian = 0))
+function infeasible_solution(::Type{T}, domain, stats) where {T <: Real}
+  return Solution{T}(nothing, domain, Int[], stats)
 end
 
 """

--- a/test/constrained_solve.jl
+++ b/test/constrained_solve.jl
@@ -168,45 +168,6 @@ end
     assert_constrained_solution(E_ppos, psi_ppos, poly_pos_obj, force_one_poly, 2.0, [1])
   end
 
-  @testset "Callbacks and stats remain available" begin
-    Q = zeros(2, 2)
-    l = [-1.0, -2.0]
-    constraints = AbstractConstraint[NotEqualsConstraint([1, 2], [1, 1])]
-    calls = Int[]
-    objectives = Float64[]
-
-    E, psi = minimize(
-      Q,
-      l;
-      constraints,
-      iterations=2,
-      verbosity=0,
-      cutoff=1e-12,
-      noise=[0.0],
-      on_iteration=(mps; iteration, objective, kw...) -> begin
-        push!(calls, iteration)
-        push!(objectives, objective)
-        callback_solution = TenSolver.Solution{Float64}(
-          deepcopy(mps),
-          0:1,
-          collect(1:length(mps)),
-          Float64[],
-          Int[],
-          Float64[],
-        )
-        @test is_feasible(TenSolver.sample(callback_solution), constraints)
-      end,
-    )
-
-    @test calls == [1, 2]
-    @test length(objectives) == 2
-    @test length(psi.energies) == 2
-    @test length(psi.bond_dims) == 2
-    @test length(psi.elapsed_times) == 2
-    @test is_feasible(TenSolver.sample(psi), constraints)
-    @test E ≈ -2.0
-  end
-
   @testset "Zero objective keeps feasible constrained samples" begin
     constraints = AbstractConstraint[ExactlyOneConstraint([1, 2], 1)]
     E, psi = minimize(
@@ -234,12 +195,6 @@ end
 
     @test E == Inf
     @test !is_feasible(psi)
-    @test isempty(psi.energies)
-    @test isempty(psi.bond_dims)
-    @test isempty(psi.elapsed_times)
-    # The solve reports; querying a nonexistent solution throws.
-    @test_throws DomainError TenSolver.sample(psi)
-    @test [0, 0] ∉ psi
 
     # The supremum over an empty feasible set is -Inf.
     Emax, psimax = @test_logs (:warn, r"empty feasible subspace") maximize(

--- a/test/qubo.jl
+++ b/test/qubo.jl
@@ -58,33 +58,9 @@
 
       @test E ≈ -2.0
       @test TenSolver.sample(psi) == [1]
-      @test psi.energies == [-2.0]
-      @test psi.bond_dims == [1]
-      @test length(psi.elapsed_times) == 1
-    end
-
-    @testset "Single variable callback" begin
-      Q = reshape([-2.0], 1, 1)
-      callback = Dict{Symbol,Any}()
-      E, psi = minimize(
-        Q;
-        verbosity = 0,
-        on_iteration = (mps; iteration, objective, bond_dim, elapsed_time) -> begin
-          callback[:iteration] = iteration
-          callback[:objective] = objective
-          callback[:bond_dim] = bond_dim
-          callback[:elapsed_time] = elapsed_time
-          callback[:mps_objectid] = objectid(mps)
-        end,
-      )
-
-      @test E ≈ -2.0
-      @test TenSolver.sample(psi) == [1]
-      @test callback[:iteration] == 1
-      @test callback[:objective] ≈ -2.0
-      @test callback[:bond_dim] == 1
-      @test callback[:elapsed_time] isa Float64
-      @test callback[:mps_objectid] isa UInt
+      @test psi.stats.energies    == [-2.0]
+      @test psi.stats.bond_dims   == [1]
+      @test length(psi.stats.elapsed_times) == 1
     end
 
     @testset "Single variable with linear and constant terms" begin
@@ -153,14 +129,14 @@
     @testset "Solution carries stats" begin
       E, psi = minimize([1.0 0; 0 -1.0]; iterations=5, verbosity = 0)
       @test psi isa TenSolver.Solution
-      @test length(psi.energies)      == 5
-      @test length(psi.bond_dims)     == 5
-      @test length(psi.elapsed_times) == 5
-      @test all(isfinite, psi.energies)
-      @test issorted(psi.elapsed_times)
-      @test all(>(0), psi.bond_dims)
-      @test isfinite(last(psi.energies))
-      @test last(psi.energies) ≈ E
+      @test length(psi.stats.energies)      == 5
+      @test length(psi.stats.bond_dims)     == 5
+      @test length(psi.stats.elapsed_times) == 5
+      @test all(isfinite, psi.stats.energies)
+      @test issorted(psi.stats.elapsed_times)
+      @test all(>(0), psi.stats.bond_dims)
+      @test isfinite(last(psi.stats.energies))
+      @test last(psi.stats.energies) ≈ E
     end
 
     @testset "on_iteration callback is called" begin


### PR DESCRIPTION
The idea is to simplify #112.
This PR exposes the initial dimensions for all operators involved in the DMRG loop. To better organize everything, we moved from parallel arrays to a new `SolverStatistics` struct.