### PR TITLE
Generalize exactly-one to assignment constraints

### DIFF
--- a/docs/internal/jump_moi_constraints.md
+++ b/docs/internal/jump_moi_constraints.md
@@ -28,7 +28,7 @@ projection MPO, and solves in the projected space. The four v1 native types are:
 
 - `SumConstraint`;
 - `NotEqualsConstraint`;
-- `ExactlyOneConstraint`; and
+- `AssignmentConstraint`; and
 - `RelationConstraint`.
 
 The JuMP path stops earlier. `TenSolver.Optimizer` is generated with
@@ -221,7 +221,7 @@ size of the uniform finite domain.
 | Nonnegative integer affine function in `Interval` | `SumConstraint` with a two-sided relation | `upper + 2` | Same domain contract; use one capped DFA and simplify a redundant side to a one-sided relation. |
 | `x[i] - x[j]` in `EqualTo(0)`, `LessThan(0)`, or `GreaterThan(0)` | `RelationConstraint(i, relation, j)` | `|U|` | Domain-independent for a common ordered finite real domain. |
 | `VectorOfVariables(x)` in `MOI.AllDifferent(length(x))` | One `RelationConstraint(i, :(!=), j)` per pair | `|U|` each | Domain-independent; statically infeasible when `length(x) > |U|`. |
-| `VectorOfVariables(x)` in a TenSolver `ExactlyOneValue(value)` set | `ExactlyOneConstraint(sites, value)` | 2 | Any uniform finite domain; a target outside the domain is statically infeasible. |
+| `VectorOfVariables(x)` in a TenSolver `ExactlyOneValue(value)` set | `AssignmentConstraint(sites, [value], :(==), 1)` | 2 | Any uniform finite domain; a target outside the domain is statically infeasible. |
 | `VectorOfVariables(x)` in `MOI.SOS1(weights)` | Domain-aware lowering | 3 for `U = {0,1}` | Boolean domains lower to `SumConstraint(..., <=, 1)`; other domains are unsupported until a compact at-most-one-nonzero target exists. |
 | `ScalarAffineFunction` in a TenSolver `NotEqualTo(value)` set | `SumConstraint(...; relation = :(!=))`, or `RelationConstraint` for a pairwise pattern | Native target's bound | General sums retain the sum target's domain restrictions. |
 | `VectorOfVariables(x)` in a TenSolver `ForbiddenAssignment(values)` set | `NotEqualsConstraint(sites, values)` | 2 | Any uniform finite domain; values outside the domain make the constraint a tautology. |
@@ -229,10 +229,10 @@ size of the uniform finite domain.
 
 Once the domain is known, the native simplifier may recover compact Boolean
 identities: `sum(x) == 1` and `sum(x) == length(x)-1` become
-`ExactlyOneConstraint` targets, and `x[i] + x[j] <= 1` becomes a forbidden
-assignment. They are not valid domain-independent MOI rewrites. A bare `SOS1`
-cannot lower to `ExactlyOneConstraint` because the all-zero assignment is
-feasible for `SOS1`.
+`AssignmentConstraint` targets that count ones and zeros, respectively, and
+`x[i] + x[j] <= 1` becomes a forbidden assignment. They are not valid
+domain-independent MOI rewrites. A bare `SOS1` cannot lower to an exact-one
+`AssignmentConstraint` because the all-zero assignment is feasible for `SOS1`.
 
 The custom `ExactlyOneValue`, `NotEqualTo`, and `ForbiddenAssignment` sets
 belong to the MOI front end. They do not replace native constraint types; they

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -50,7 +50,7 @@ for a worked example.
 TenSolver.AbstractConstraint
 TenSolver.SumConstraint
 TenSolver.NotEqualsConstraint
-TenSolver.ExactlyOneConstraint
+TenSolver.AssignmentConstraint
 TenSolver.RelationConstraint
 TenSolver.is_feasible
 TenSolver.constraint_sites

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -43,7 +43,7 @@ keep constrained solves close to the unconstrained cost.
 |:-----------|:---------|:------------------------|
 | [`SumConstraint`](@ref) | ``\sum_i w_i \, x_{s_i} \lessgtr b`` | ``b + 2`` (independent of the number of variables) |
 | [`NotEqualsConstraint`](@ref) | ``x_S \ne v`` (one forbidden assignment) | 2 |
-| [`AssignmentConstraint`](@ref) | ``\mathrm{count}_{i \in S}(x_i \in G) \lessgtr b`` | ``b + 1`` for `==`, `<=`, `>=`; ``b + 2`` for `!=` |
+| [`AssignmentConstraint`](@ref) | ``\mathrm{count}_{i \in S}(x_i \in G) \lessgtr b`` | ``b + 2`` |
 | [`RelationConstraint`](@ref) | ``x_i \lessgtr x_j`` | 2 |
 
 ## Using constraints
@@ -135,9 +135,7 @@ restricts how many selected sites take a value in `values`:
 \#\{\, s \in \texttt{sites} : x_s \in \texttt{values} \,\} \;\; \texttt{relation} \;\; \texttt{rhs}.
 ```
 
-For rhs `k`, its automaton has maximum bond dimension `k+1` for `==`, `<=`,
-and `>=`, and `k+2` for `!=`. If `k` is larger than the number of selected
-sites, the predicate is constant and the automaton has one state.
+For rhs `k`, its automaton has maximum bond dimension `k+2`.
 
 ```jldoctest onehot
 using TenSolver

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -43,7 +43,7 @@ keep constrained solves close to the unconstrained cost.
 |:-----------|:---------|:------------------------|
 | [`SumConstraint`](@ref) | ``\sum_i w_i \, x_{s_i} \lessgtr b`` | ``b + 2`` (independent of the number of variables) |
 | [`NotEqualsConstraint`](@ref) | ``x_S \ne v`` (one forbidden assignment) | 2 |
-| [`AssignmentConstraint`](@ref) | ``\mathrm{count}_{i \in S}(x_i in G) \lessgtr b`` | 2 |
+| [`AssignmentConstraint`](@ref) | ``\mathrm{count}_{i \in S}(x_i \in G) \lessgtr b`` | ``b + 1`` for `==`, `<=`, `>=`; ``b + 2`` for `!=` |
 | [`RelationConstraint`](@ref) | ``x_i \lessgtr x_j`` | 2 |
 
 ## Using constraints
@@ -129,19 +129,21 @@ E, psi = TenSolver.minimize(zeros(2, 2), [-2.0, -1.0]; constraints = [exclude], 
 ### AssignmentConstraint
 
 `AssignmentConstraint(sites, values, rel, rhs)`
-forces an assignment of a fixed amount of the selected sites to be in `values`:
+restricts how many selected sites take a value in `values`:
 
 ```math
-\#\{\, s \in \texttt{sites} : x_s in \texttt{values} \,\} \;\; \texttt{relation} \;\; \texttt{rhs},
+\#\{\, s \in \texttt{sites} : x_s \in \texttt{values} \,\} \;\; \texttt{relation} \;\; \texttt{rhs}.
 ```
 
-Similarly to the weighted sum, its automaton has maximum bond dimension `k+2`.
+For rhs `k`, its automaton has maximum bond dimension `k+1` for `==`, `<=`,
+and `>=`, and `k+2` for `!=`. If `k` is larger than the number of selected
+sites, the predicate is constant and the automaton has one state.
 
 ```jldoctest onehot
 using TenSolver
 
 # Pick exactly one of the three options; the second is the most valuable.
-one_hot = AssignmentConstraint([1, 2, 3], 1, :(==), 1)
+one_hot = AssignmentConstraint([1, 2, 3], [1], :(==), 1)
 
 E, psi = TenSolver.minimize(zeros(3, 3), [-1.0, -3.0, -2.0]; constraints = [one_hot], verbosity = 0)
 
@@ -185,7 +187,7 @@ using TenSolver
 constraints = [
     SumConstraint([1, 2, 3], [1, 1, 1], 2; relation = :(<=)),
     NotEqualsConstraint([1, 2], [1, 1]),
-    AssignmentConstraint([2, 3], 1, :(==), 1),
+    AssignmentConstraint([2, 3], [1], :(==), 1),
     RelationConstraint(1, :(>=), 3),
 ]
 

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -43,7 +43,7 @@ keep constrained solves close to the unconstrained cost.
 |:-----------|:---------|:------------------------|
 | [`SumConstraint`](@ref) | ``\sum_i w_i \, x_{s_i} \lessgtr b`` | ``b + 2`` (independent of the number of variables) |
 | [`NotEqualsConstraint`](@ref) | ``x_S \ne v`` (one forbidden assignment) | 2 |
-| [`ExactlyOneConstraint`](@ref) | ``\mathrm{count}_{i \in S}(x_i = k) = 1`` | 2 |
+| [`AssignmentConstraint`](@ref) | ``\mathrm{count}_{i \in S}(x_i in G) \lessgtr b`` | 2 |
 | [`RelationConstraint`](@ref) | ``x_i \lessgtr x_j`` | 2 |
 
 ## Using constraints
@@ -126,22 +126,22 @@ E, psi = TenSolver.minimize(zeros(2, 2), [-2.0, -1.0]; constraints = [exclude], 
 (true, [1.0, 0.0])
 ```
 
-### ExactlyOneConstraint
+### AssignmentConstraint
 
-`ExactlyOneConstraint(sites, value)` requires exactly one of the selected sites
-to equal `value`:
+`AssignmentConstraint(sites, values, rel, rhs)`
+forces an assignment of a fixed amount of the selected sites to be in `values`:
 
 ```math
-\#\{\, s \in \texttt{sites} : x_s = \texttt{value} \,\} = 1.
+\#\{\, s \in \texttt{sites} : x_s in \texttt{values} \,\} \;\; \texttt{relation} \;\; \texttt{rhs},
 ```
 
-Its specialized automaton has bond dimension 2.
+Similarly to the weighted sum, its automaton has maximum bond dimension `k+2`.
 
 ```jldoctest onehot
 using TenSolver
 
 # Pick exactly one of the three options; the second is the most valuable.
-one_hot = ExactlyOneConstraint([1, 2, 3], 1)
+one_hot = AssignmentConstraint([1, 2, 3], 1, :(==), 1)
 
 E, psi = TenSolver.minimize(zeros(3, 3), [-1.0, -3.0, -2.0]; constraints = [one_hot], verbosity = 0)
 
@@ -176,8 +176,8 @@ E, psi = TenSolver.minimize(zeros(2, 2), [-2.0, 1.0]; constraints = [implies], v
 
 ## Combining constraints
 
-Passing several constraints applies their conjunction — the feasible set is the
-intersection. All four types compose freely:
+Passing several constraints applies their conjunction.
+All four types compose freely:
 
 ```jldoctest combined
 using TenSolver
@@ -185,7 +185,7 @@ using TenSolver
 constraints = [
     SumConstraint([1, 2, 3], [1, 1, 1], 2; relation = :(<=)),
     NotEqualsConstraint([1, 2], [1, 1]),
-    ExactlyOneConstraint([2, 3], 1),
+    AssignmentConstraint([2, 3], 1, :(==), 1),
     RelationConstraint(1, :(>=), 3),
 ]
 

--- a/src/TenSolver.jl
+++ b/src/TenSolver.jl
@@ -14,7 +14,7 @@ export bool_to_spin, spin_to_bool, qubo_to_ising, ising_to_qubo
 
 include("constraints.jl")
 export AbstractConstraint
-export SumConstraint, NotEqualsConstraint, ExactlyOneConstraint, RelationConstraint
+export SumConstraint, NotEqualsConstraint, AssignmentConstraint, RelationConstraint
 export is_feasible
 
 include("projection_mpo.jl")

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -17,7 +17,7 @@ Julia lowering target for projection-MPO constrained solves; future JuMP/MOI
 integration may change which constraint abstraction is considered stable public API.
 
 See also [`SumConstraint`](@ref), [`NotEqualsConstraint`](@ref),
-[`ExactlyOneConstraint`](@ref), and [`RelationConstraint`](@ref).
+[`AssignmentConstraint`](@ref), and [`RelationConstraint`](@ref).
 """
 abstract type AbstractConstraint end
 
@@ -103,28 +103,36 @@ function NotEqualsConstraint(sites, values)
 end
 
 """
-    ExactlyOneConstraint{T} <: AbstractConstraint
-    ExactlyOneConstraint(sites, value)
+    AssignmentConstraint{T} <: AbstractConstraint
+    AssignmentConstraint(sites, values, relation, rhs)
 
-Requires exactly one site in `sites` to satisfy `x[site] == value`, i.e.,
+Require a fixed amount of `sites` to satisfy `x[site] in value`, i.e.,
 
-    count(x[site] == value for site in sites) == 1.
+    count(x[site] in value for site in sites) relation rhs.
 
-`sites` must be unique positive integers, and `value` must be `0` or `1`.
+A common application is to restrict _exactly one_ variable to be a certain value,
+
+```julia
+ExactlyOne(sites, value) = AssignmentConstraint(sites, [value], :(==), 1)
+```
 """
-struct ExactlyOneConstraint{T<:Real} <: AbstractConstraint
-  sites::Vector{Int}
-  value::T
+struct AssignmentConstraint{T<:Real} <: AbstractConstraint
+  sites    :: Vector{Int}
+  values   :: Set{T}
+  relation :: Symbol
+  rhs      :: T
 
-  function ExactlyOneConstraint{T}(sites, value::T) where {T<:Real}
+  function AssignmentConstraint{T}(sites, values, relation, rhs) where {T<:Real}
     site_vec = validate_sites(sites)
+    relation = validate_relation(relation)
+    rhs      = validate_rhs(rhs)
 
-    return new{T}(site_vec, value)
+    return new{T}(site_vec, Set(values), relation, rhs)
   end
 end
 
-function ExactlyOneConstraint(sites, value::T) where T
-  return ExactlyOneConstraint{T}(sites, value)
+function AssignmentConstraint(sites, values, relation, rhs)
+  return AssignmentConstraint{eltype(values)}(sites, values, relation, rhs)
 end
 
 """
@@ -167,8 +175,9 @@ function is_feasible(x::AbstractVector, constraint::NotEqualsConstraint)
   return any(x[site] != value for (site, value) in constraint.values)
 end
 
-function is_feasible(x::AbstractVector, constraint::ExactlyOneConstraint)
-  return count(site -> x[site] == constraint.value, constraint.sites) == 1
+function is_feasible(x::AbstractVector, constraint::AssignmentConstraint)
+  lhs = count(site -> x[site] in constraint.values, constraint.sites)
+  return relation_holds(lhs, constraint.relation, constraint.rhs)
 end
 
 function is_feasible(x::AbstractVector, constraint::RelationConstraint)
@@ -204,7 +213,7 @@ function constraint_sites(constraint::NotEqualsConstraint)
   return keys(constraint.values)
 end
 
-function constraint_sites(constraint::ExactlyOneConstraint)
+function constraint_sites(constraint::AssignmentConstraint)
   return constraint.sites
 end
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -106,9 +106,12 @@ end
     AssignmentConstraint{T} <: AbstractConstraint
     AssignmentConstraint(sites, values, relation, rhs)
 
-Require a fixed amount of `sites` to satisfy `x[site] in value`, i.e.,
+Restrict how many `sites` satisfy `x[site] in values`, i.e.,
 
-    count(x[site] in value for site in sites) relation rhs.
+    count(x[site] in values for site in sites) relation rhs.
+
+`rhs` must be a nonnegative integer. The count and `rhs` are stored
+independently of the numeric element type of `values`.
 
 A common application is to restrict _exactly one_ variable to be a certain value,
 
@@ -120,12 +123,12 @@ struct AssignmentConstraint{T<:Real} <: AbstractConstraint
   sites    :: Vector{Int}
   values   :: Set{T}
   relation :: Symbol
-  rhs      :: T
+  rhs      :: Int
 
   function AssignmentConstraint{T}(sites, values, relation, rhs) where {T<:Real}
     site_vec = validate_sites(sites)
     relation = validate_relation(relation)
-    rhs      = validate_rhs(rhs)
+    rhs      = Int(validate_rhs(rhs))
 
     return new{T}(site_vec, Set(values), relation, rhs)
   end

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -230,13 +230,13 @@ Constraint site numbers use the same 1-based register indexing as `sites`.
 
 # Known constraints
 
-- [`SumConstraint`](@ref) uses a specialized exact integer partial-sum automaton.
-For a constraint with rhs `k`, its maximum bond dimension is `k+2`.
-- [`NotEqualsConstraint`](@ref) uses a specialized MPO with bond dimension `2`,
+- [`SumConstraint`](@ref) uses a exact integer partial-sum automaton.
+  For a constraint with rhs `k`, its maximum bond dimension is `k+2`.
+- [`NotEqualsConstraint`](@ref) uses a MPO with bond dimension `2`,
   independently of the rhs.
-- [`ExactlyOneConstraint`](@ref) uses a specialized MPO with bond dimension `2`
-  that tracks whether the target value has been seen exactly once.
-- [`RelationConstraint`](@ref) uses a specialized MPO with bond dimension `2`,
+- [`AssignmentConstraint`](@ref) uses a membership counting automaton.
+  For a constraint with rhs `k`, its maximum bond dimension is `k+2`.
+- [`RelationConstraint`](@ref) uses a MPO with bond dimension `2`,
   independently of the compared site positions.
 """
 function projection_mpo end
@@ -395,21 +395,22 @@ function constraint_to_dfa(constraint::NotEqualsConstraint{S}, nsites::Integer, 
   return DFA(states, alphabet, initial, accepting, transitions)
 end
 
-function constraint_to_dfa(constraint::ExactlyOneConstraint{S}, nsites::Integer, alphabet) where {S}
-  target = constraint.value
+function constraint_to_dfa(constraint::AssignmentConstraint{S}, nsites::Integer, alphabet) where {S}
+  (; values, rhs, relation) = constraint
+  beyond    = rhs + one(S)
 
-  states    = [:not_seen, :seen_once]
-  initial   = :not_seen
-  accepting = Set([:seen_once])
+  states    = zero(S):beyond
+  initial   = zero(S)
+  accepting = Set(q for q in states if relation_holds(q, relation, rhs))
 
   id_dict = Dict((q, a) => q for q in states for a in alphabet)
   transitions = fill(id_dict, nsites)
 
+  f(_, a) = S(a in values)
   for site in constraint_sites(constraint)
     transitions[site] = Dict(
-      (q, a) => (a == target ? :seen_once : q)
+      (q, a) => min(q + f(site, a), beyond)
       for q in states, a in alphabet
-      if !(q == :seen_once && a == target)
     )
   end
 

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -235,9 +235,7 @@ Constraint site numbers use the same 1-based register indexing as `sites`.
 - [`NotEqualsConstraint`](@ref) uses a MPO with bond dimension `2`,
   independently of the rhs.
 - [`AssignmentConstraint`](@ref) uses a membership counting automaton.
-  For rhs `k`, the maximum bond dimension is `k+1` for `==`, `<=`, and `>=`,
-  and `k+2` for `!=`. A rhs larger than the number of selected sites reduces
-  to a one-state constant automaton.
+  For rhs `k`, the maximum bond dimension is `k+2`.
 - [`RelationConstraint`](@ref) uses a MPO with bond dimension `2`,
   independently of the compared site positions.
 """

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -213,7 +213,7 @@ function dfa_to_mpo(::Type{T}, dfa::DFA, sites) where {T}
     )
   end
 
-  return ITensorMPS.MPO(tensors)
+  return ITensorMPS.truncate!(ITensorMPS.MPO(tensors); cutoff = eps(T))
 end
 
 dfa_to_mpo(dfa::DFA, sites) = dfa_to_mpo(Float64, dfa, sites)
@@ -395,34 +395,22 @@ function constraint_to_dfa(constraint::NotEqualsConstraint{S}, nsites::Integer, 
   return DFA(states, alphabet, initial, accepting, transitions)
 end
 
-function constraint_to_dfa(constraint::AssignmentConstraint, nsites::Integer, alphabet)
+function constraint_to_dfa(constraint::AssignmentConstraint{S}, nsites::Integer, alphabet) where {S}
   (; values, rhs, relation) = constraint
+  beyond    = rhs + one(S)
 
-  if rhs > length(constraint.sites)
-    states = [0]
-    accepting = relation_holds(0, relation, rhs) ? Set([0]) : Set{Int}()
-    id_dict = Dict((0, a) => 0 for a in alphabet)
-    transitions = fill(id_dict, nsites)
-    for site in constraint_sites(constraint)
-      transitions[site] = id_dict
-    end
-    return DFA(states, alphabet, 0, accepting, transitions)
-  end
-
-  beyond = relation === :(!=) ? rhs + 1 : rhs
-  states = 0:beyond
-  initial = 0
+  states    = zero(S):beyond
+  initial   = zero(S)
   accepting = Set(q for q in states if relation_holds(q, relation, rhs))
 
   id_dict = Dict((q, a) => q for q in states for a in alphabet)
   transitions = fill(id_dict, nsites)
 
-  rejects_overflow(q, a) = relation in (:(==), :(<=)) && q == rhs && a in values
+  f(_, a) = S(a in values)
   for site in constraint_sites(constraint)
     transitions[site] = Dict(
-      (q, a) => min(q + Int(a in values), beyond)
+      (q, a) => min(q + f(site, a), beyond)
       for q in states, a in alphabet
-      if !rejects_overflow(q, a)
     )
   end
 

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -235,7 +235,9 @@ Constraint site numbers use the same 1-based register indexing as `sites`.
 - [`NotEqualsConstraint`](@ref) uses a MPO with bond dimension `2`,
   independently of the rhs.
 - [`AssignmentConstraint`](@ref) uses a membership counting automaton.
-  For a constraint with rhs `k`, its maximum bond dimension is `k+2`.
+  For rhs `k`, the maximum bond dimension is `k+1` for `==`, `<=`, and `>=`,
+  and `k+2` for `!=`. A rhs larger than the number of selected sites reduces
+  to a one-state constant automaton.
 - [`RelationConstraint`](@ref) uses a MPO with bond dimension `2`,
   independently of the compared site positions.
 """
@@ -395,22 +397,34 @@ function constraint_to_dfa(constraint::NotEqualsConstraint{S}, nsites::Integer, 
   return DFA(states, alphabet, initial, accepting, transitions)
 end
 
-function constraint_to_dfa(constraint::AssignmentConstraint{S}, nsites::Integer, alphabet) where {S}
+function constraint_to_dfa(constraint::AssignmentConstraint, nsites::Integer, alphabet)
   (; values, rhs, relation) = constraint
-  beyond    = rhs + one(S)
 
-  states    = zero(S):beyond
-  initial   = zero(S)
+  if rhs > length(constraint.sites)
+    states = [0]
+    accepting = relation_holds(0, relation, rhs) ? Set([0]) : Set{Int}()
+    id_dict = Dict((0, a) => 0 for a in alphabet)
+    transitions = fill(id_dict, nsites)
+    for site in constraint_sites(constraint)
+      transitions[site] = id_dict
+    end
+    return DFA(states, alphabet, 0, accepting, transitions)
+  end
+
+  beyond = relation === :(!=) ? rhs + 1 : rhs
+  states = 0:beyond
+  initial = 0
   accepting = Set(q for q in states if relation_holds(q, relation, rhs))
 
   id_dict = Dict((q, a) => q for q in states for a in alphabet)
   transitions = fill(id_dict, nsites)
 
-  f(_, a) = S(a in values)
+  rejects_overflow(q, a) = relation in (:(==), :(<=)) && q == rhs && a in values
   for site in constraint_sites(constraint)
     transitions[site] = Dict(
-      (q, a) => min(q + f(site, a), beyond)
+      (q, a) => min(q + Int(a in values), beyond)
       for q in states, a in alphabet
+      if !rejects_overflow(q, a)
     )
   end
 

--- a/test/constrained_solve.jl
+++ b/test/constrained_solve.jl
@@ -17,7 +17,7 @@ end
   all_constraint_types = AbstractConstraint[
     SumConstraint([1, 2, 3], [1, 1, 1], 2; relation=:(<=)),
     NotEqualsConstraint([1, 2], [1, 1]),
-    ExactlyOneConstraint([2, 3], 1),
+    AssignmentConstraint([2, 3], [1], :(==), 1),
     RelationConstraint(1, :(>=), 3),
   ]
 
@@ -59,7 +59,7 @@ end
   @testset "Maximize forwards constraints" begin
     Q = zeros(2, 2)
     l = [1.0, 2.0]
-    constraints = AbstractConstraint[ExactlyOneConstraint([1, 2], 1)]
+    constraints = AbstractConstraint[AssignmentConstraint([1, 2], 1, :(==), 1)]
     obj(x) = dot(x, Q, x) + dot(l, x)
 
     E, psi = maximize(
@@ -117,7 +117,7 @@ end
 
     DynamicPolynomials.@polyvar z
     p = -2.0z + 0.0
-    force_one = AbstractConstraint[ExactlyOneConstraint([1], 1)]
+    force_one = AbstractConstraint[AssignmentConstraint([1], 1, :(==), 1)]
     poly_obj(x) = p([z] => x)
 
     E_poly, psi_poly = minimize(
@@ -153,7 +153,7 @@ end
 
     DynamicPolynomials.@polyvar w
     p_pos = 2.0w + 0.0
-    force_one_poly = AbstractConstraint[ExactlyOneConstraint([1], 1)]
+    force_one_poly = AbstractConstraint[AssignmentConstraint([1], 1, :(==), 1)]
     poly_pos_obj(x) = p_pos([w] => x)
 
     E_ppos, psi_ppos = minimize(
@@ -169,7 +169,7 @@ end
   end
 
   @testset "Zero objective keeps feasible constrained samples" begin
-    constraints = AbstractConstraint[ExactlyOneConstraint([1, 2], 1)]
+    constraints = AbstractConstraint[AssignmentConstraint([1, 2], 1, :(==), 1)]
     E, psi = minimize(
       zeros(2, 2);
       constraints,
@@ -297,7 +297,7 @@ end
     Random.seed!(20260715)
 
     l = [-1.0, -1.0]
-    constraints = AbstractConstraint[ExactlyOneConstraint([1, 2], 1)]
+    constraints = AbstractConstraint[AssignmentConstraint([1, 2], 1, :(==), 1)]
 
     E, psi = minimize(
       zeros(2, 2),

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -2,7 +2,6 @@
   @testset "Constructors" begin
     sum = SumConstraint([1, 3], [2, 1], Symbol("<="), 2)
     @test sum isa SumConstraint
-    @test sum isa AbstractConstraint
     @test Set(TenSolver.constraint_sites(sum)) == Set([1, 3])
     @test sum.weights == Dict(1 => 2, 3 => 1)
     @test sum.relation == Symbol("<=")
@@ -15,7 +14,6 @@
 
     not_equals = NotEqualsConstraint([1, 2], [1, 0])
     @test not_equals isa NotEqualsConstraint{Int}
-    @test not_equals isa AbstractConstraint
     @test Set(TenSolver.constraint_sites(not_equals)) == Set([1, 2])
     @test not_equals.values == Dict(1 => 1, 2 => 0)
 
@@ -24,16 +22,15 @@
     @test Set(TenSolver.constraint_sites(float_not_equals)) == Set([1, 2])
     @test float_not_equals.values == Dict(1 => 1.0, 2 => 0.0)
 
-    exactly_one = ExactlyOneConstraint(2:4, 1)
-    @test exactly_one isa ExactlyOneConstraint{Int}
-    @test exactly_one isa AbstractConstraint
+    exactly_one = AssignmentConstraint(2:4, [1], :(==), 1)
+    @test exactly_one isa AssignmentConstraint{Int}
     @test exactly_one.sites == [2, 3, 4]
-    @test exactly_one.value == 1
+    @test exactly_one.values == Set([1])
 
-    exactly_one_zero = ExactlyOneConstraint(2:4, 0)
-    @test exactly_one_zero isa ExactlyOneConstraint
-    @test exactly_one_zero.sites == [2, 3, 4]
-    @test exactly_one_zero.value == 0
+    assign_two = AssignmentConstraint(2:4, [1, 2, 3], :(<=), 2)
+    @test assign_two isa AssignmentConstraint{Int}
+    @test assign_two.sites == [2, 3, 4]
+    @test assign_two.values == Set([1, 2, 3])
 
     relation = RelationConstraint(1, Symbol(">="), 2)
     @test relation isa RelationConstraint
@@ -44,10 +41,10 @@
   end
 
   @testset "Constructor validation" begin
-    @test_throws ArgumentError ExactlyOneConstraint(Int[], 1)
-    @test_throws ArgumentError ExactlyOneConstraint([0], 1)
-    @test_throws ArgumentError ExactlyOneConstraint([1, 1], 1)
-    @test_throws ArgumentError ExactlyOneConstraint([1.0], 1)
+    @test_throws ArgumentError AssignmentConstraint(Int[], 1, :(==), 1)
+    @test_throws ArgumentError AssignmentConstraint([0], 1, :(==), 1)
+    @test_throws ArgumentError AssignmentConstraint([1, 1], 1, :(==), 1)
+    @test_throws ArgumentError AssignmentConstraint([1.0], 1, :(==), 1)
 
     @test_throws DimensionMismatch SumConstraint([1, 2], [1], Symbol("=="), 1)
     @test_throws ArgumentError SumConstraint([1], [-1], Symbol("=="), 0)
@@ -87,13 +84,13 @@
     @test !is_feasible([1, 1, 0], not_equals)
     @test is_feasible([1, 1, 1], not_equals)
 
-    exactly_one = ExactlyOneConstraint([2, 3, 4], 1)
+    exactly_one = AssignmentConstraint(2:4, [1], :(==), 1)
     @test is_feasible([0, 1, 0, 0], exactly_one)
     @test !is_feasible([0, 1, 1, 0], exactly_one)
 
-    exactly_one_zero = ExactlyOneConstraint([2, 3, 4], 0)
-    @test is_feasible([1, 0, 1, 1], exactly_one_zero)
-    @test !is_feasible([1, 0, 1, 0], exactly_one_zero)
+    assign_two = AssignmentConstraint(2:4, [1, 2, 3], :(<=), 2)
+    @test is_feasible([0, 2, 0, 0], assign_two)
+    @test !is_feasible([0, 2, 1, 2], assign_two)
 
     relation = RelationConstraint(1, Symbol("<="), 2)
     @test is_feasible([0, 1], relation)
@@ -108,7 +105,7 @@
     @test is_feasible([1, 0], AbstractConstraint[])
 
     mixed_constraints = AbstractConstraint[
-      ExactlyOneConstraint([1, 2], 0),
+      AssignmentConstraint([1, 2], 0, :(==), 1),
       RelationConstraint(1, Symbol(">="), 2),
     ]
     @test is_feasible([1, 0], mixed_constraints)

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -31,6 +31,17 @@
     @test assign_two isa AssignmentConstraint{Int}
     @test assign_two.sites == [2, 3, 4]
     @test assign_two.values == Set([1, 2, 3])
+    @test assign_two.rhs == 2
+
+    bool_assignment = AssignmentConstraint(1:3, Bool[true], :(==), 2)
+    @test bool_assignment isa AssignmentConstraint{Bool}
+    @test bool_assignment.values == Set(Bool[true])
+    @test bool_assignment.rhs == 2
+
+    narrow_assignment = AssignmentConstraint([1], Int8[1], :(==), 128)
+    @test narrow_assignment isa AssignmentConstraint{Int8}
+    @test narrow_assignment.values == Set(Int8[1])
+    @test narrow_assignment.rhs == 128
 
     relation = RelationConstraint(1, Symbol(">="), 2)
     @test relation isa RelationConstraint
@@ -45,6 +56,9 @@
     @test_throws ArgumentError AssignmentConstraint([0], 1, :(==), 1)
     @test_throws ArgumentError AssignmentConstraint([1, 1], 1, :(==), 1)
     @test_throws ArgumentError AssignmentConstraint([1.0], 1, :(==), 1)
+    @test_throws ArgumentError AssignmentConstraint([1], [1], :(==), -1)
+    @test_throws ArgumentError AssignmentConstraint([1], [1], :(==), 1.5)
+    @test_throws ArgumentError AssignmentConstraint([1], [1], :(<), 1)
 
     @test_throws DimensionMismatch SumConstraint([1, 2], [1], Symbol("=="), 1)
     @test_throws ArgumentError SumConstraint([1], [-1], Symbol("=="), 0)

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -8,12 +8,13 @@ function mpo_diagonal(H, sites, bits)
   return real(ITensors.inner(psi', H, psi))
 end
 
-function assert_projection_matches_feasibility(constraint, sites)
-  H = TenSolver.projection_mpo(constraint, sites; domain = 0:1)
+function assert_projection_matches_feasibility(constraint, sites; domain = 0:1)
+  H = TenSolver.projection_mpo(constraint, sites; domain)
 
-  for bits in all_bitstrings(sites)
-    expected = Float64(is_feasible(collect(bits), constraint))
-    @test mpo_diagonal(H, sites, bits) == expected
+  assignments = Iterators.product(fill(domain, length(sites))...)
+  for assignment in assignments
+    expected = Float64(is_feasible(collect(assignment), constraint))
+    @test mpo_diagonal(H, sites, assignment) == expected
   end
 
   return H
@@ -279,19 +280,60 @@ end
   end
 
   @testset "AssignmentConstraint projection" begin
-    cases = [
-      (AssignmentConstraint(1:2, [1], :(==), 1), ITensors.siteinds("Qudit", 2; dim=2)),
-      (AssignmentConstraint(1:3, [0], :(==), 1), ITensors.siteinds("Qudit", 3; dim=2)),
-      (AssignmentConstraint(1:5, [1], :(==), 1), ITensors.siteinds("Qudit", 5; dim=2)),
+    domain = 0:2
+    generalized_cases = [
+      AssignmentConstraint([1, 3], [1, 2], relation, rhs)
+      for relation in (:(==), :(!=), :(<=), :(>=))
+      for rhs in (0, 1, 2, 3)
     ]
 
-    for (constraint, sites) in cases
-      dfa = @inferred TenSolver.constraint_to_dfa(constraint, length(sites), 0:1)
-      @test_broken length(dfa.states) == 2
+    for constraint in generalized_cases
+      dfa = TenSolver.constraint_to_dfa(constraint, 3, domain)
+      if constraint.rhs > length(constraint.sites)
+        @test length(dfa.states) == 1
+      end
 
-      H = assert_projection_matches_feasibility(constraint, sites)
-      @test_broken ITensorMPS.maxlinkdim(H) <= 2
+      for assignment in Iterators.product(fill(domain, 3)...)
+        @test dfa_accepts(dfa, assignment) == is_feasible(collect(assignment), constraint)
+      end
     end
+
+    projection_sites = ITensors.siteinds("Qudit", 3; dim=3)
+    for relation in (:(==), :(!=), :(<=), :(>=))
+      constraint = AssignmentConstraint([1, 3], [1, 2], relation, 1)
+      assert_projection_matches_feasibility(constraint, projection_sites; domain)
+    end
+
+    bool_assignment = AssignmentConstraint([1, 3, 4], Bool[true], :(==), 2)
+    bool_dfa = @inferred TenSolver.constraint_to_dfa(bool_assignment, 4, 0:1)
+    for bits in all_bitstrings(4)
+      @test dfa_accepts(bool_dfa, bits) == is_feasible(collect(bits), bool_assignment)
+    end
+
+    narrow_assignment = AssignmentConstraint([1], Int8[1], :(==), 128)
+    narrow_dfa = @inferred TenSolver.constraint_to_dfa(narrow_assignment, 1, 0:1)
+    @test length(narrow_dfa.states) == 1
+    @test !dfa_accepts(narrow_dfa, (1,))
+
+    @test_throws BoundsError TenSolver.constraint_to_dfa(
+      AssignmentConstraint([4], [1], :(==), 2),
+      3,
+      domain,
+    )
+
+    exact_one_sites = ITensors.siteinds("Qudit", 5; dim=2)
+    for relation in (:(==), :(<=), :(>=))
+      exact_one = AssignmentConstraint(1:5, [1], relation, 1)
+      dfa = @inferred TenSolver.constraint_to_dfa(exact_one, 5, 0:1)
+      H = assert_projection_matches_feasibility(exact_one, exact_one_sites)
+
+      @test length(dfa.states) == 2
+      @test ITensorMPS.maxlinkdim(H) <= 2
+    end
+
+    not_exactly_one = AssignmentConstraint(1:5, [1], :(!=), 1)
+    not_equal_dfa = @inferred TenSolver.constraint_to_dfa(not_exactly_one, 5, 0:1)
+    @test length(not_equal_dfa.states) == 3
   end
 
   @testset "RelationConstraint projection" begin
@@ -314,17 +356,6 @@ end
       H = assert_projection_matches_feasibility(constraint, sites)
       @test ITensorMPS.maxlinkdim(H) <= 2
     end
-  end
-
-  @testset "AssignmentConstraint projection" begin
-    sites = ITensors.siteinds("Qudit", 4; dim=2)
-
-    exact_one = AssignmentConstraint([1, 3], [1], :(>=), 1)
-    dfa = TenSolver.constraint_to_dfa(exact_one, length(sites),  0:1)
-    H = assert_projection_matches_feasibility(exact_one, sites)
-
-    @test_broken length(dfa.states) == 2
-    @test_broken ITensorMPS.maxlinkdim(H) <= 2
   end
 
   @testset "SumConstraint floating-point lowering" begin

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -14,7 +14,7 @@ function assert_projection_matches_feasibility(constraint, sites; domain = 0:1)
   assignments = Iterators.product(fill(domain, length(sites))...)
   for assignment in assignments
     expected = Float64(is_feasible(collect(assignment), constraint))
-    @test mpo_diagonal(H, sites, assignment) == expected
+    @test mpo_diagonal(H, sites, assignment) ≈ expected atol=sqrt(eps(Float64))
   end
 
   return H
@@ -99,7 +99,7 @@ end
 
       for bits in all_bitstrings(sites)
         expected = is_feasible(collect(bits), constraint)
-        @test dfa_accepts(dfa, bits) == expected
+        @test dfa_accepts(dfa, bits) ≈ expected atol=1e-8
       end
     end
   end
@@ -119,14 +119,14 @@ end
         end
 
         for i in 1:length(sites)-1
-          @test ITensorMPS.linkdim(H, i) == length(dfa.states)
+          @test ITensorMPS.linkdim(H, i) <= length(dfa.states)
         end
       end
 
       @testset "MPO Diagonal matches acceptance" begin
         for bits in all_bitstrings(sites)
           expected = Float64(dfa_accepts(dfa, bits))
-          @test mpo_diagonal(H, sites, bits) ≈ expected
+          @test mpo_diagonal(H, sites, bits) ≈ expected atol=1e-8
         end
       end
     end
@@ -199,7 +199,7 @@ end
       # tensor-order bits -> original-order bits
       original_bits = collect(bits)[invperm(perm)]
       expected = Float64(is_feasible(original_bits, constraint))
-      @test mpo_diagonal(H, sites, bits) ≈ expected
+      @test mpo_diagonal(H, sites, bits) ≈ expected atol=1e-8
     end
   end
 
@@ -221,7 +221,7 @@ end
       for bits in all_bitstrings(sites)
         original_bits = collect(bits)[invperm(perm)]
         expected = Float64(is_feasible(original_bits, constraint))
-        @test mpo_diagonal(H, sites, bits) ≈ expected
+        @test mpo_diagonal(H, sites, bits) ≈ expected atol=1e-8
       end
     end
   end
@@ -241,7 +241,7 @@ end
     end
 
     for bits in all_bitstrings(sites)
-      @test mps_amplitude(projected_psi, sites, bits) == 0.0
+      @test mps_amplitude(projected_psi, sites, bits) ≈ 0.0 atol=1e-8
     end
   end
 
@@ -253,7 +253,7 @@ end
 
     for bits in all_bitstrings(sites)
       forbidden = bits[1] == 1 && bits[3] == 0 && bits[4] == 1
-      @test mpo_diagonal(H, sites, bits) == Float64(!forbidden)
+      @test mpo_diagonal(H, sites, bits) ≈ !forbidden atol=1e-8
     end
     @test ITensorMPS.maxlinkdim(H) <= 2
 
@@ -268,7 +268,7 @@ end
 
       for bits in all_bitstrings(sites)
         forbidden = bits[left] == 1 && bits[right] == 1
-        @test mpo_diagonal(local_H, sites, bits) == Float64(!forbidden)
+        @test mpo_diagonal(local_H, sites, bits) ≈ !forbidden atol=1e-8
       end
       @test ITensorMPS.maxlinkdim(local_H) <= 2
     end
@@ -289,9 +289,6 @@ end
 
     for constraint in generalized_cases
       dfa = TenSolver.constraint_to_dfa(constraint, 3, domain)
-      if constraint.rhs > length(constraint.sites)
-        @test length(dfa.states) == 1
-      end
 
       for assignment in Iterators.product(fill(domain, 3)...)
         @test dfa_accepts(dfa, assignment) == is_feasible(collect(assignment), constraint)
@@ -310,11 +307,6 @@ end
       @test dfa_accepts(bool_dfa, bits) == is_feasible(collect(bits), bool_assignment)
     end
 
-    narrow_assignment = AssignmentConstraint([1], Int8[1], :(==), 128)
-    narrow_dfa = @inferred TenSolver.constraint_to_dfa(narrow_assignment, 1, 0:1)
-    @test length(narrow_dfa.states) == 1
-    @test !dfa_accepts(narrow_dfa, (1,))
-
     @test_throws BoundsError TenSolver.constraint_to_dfa(
       AssignmentConstraint([4], [1], :(==), 2),
       3,
@@ -327,13 +319,12 @@ end
       dfa = @inferred TenSolver.constraint_to_dfa(exact_one, 5, 0:1)
       H = assert_projection_matches_feasibility(exact_one, exact_one_sites)
 
-      @test length(dfa.states) == 2
       @test ITensorMPS.maxlinkdim(H) <= 2
     end
 
     not_exactly_one = AssignmentConstraint(1:5, [1], :(!=), 1)
     not_equal_dfa = @inferred TenSolver.constraint_to_dfa(not_exactly_one, 5, 0:1)
-    @test length(not_equal_dfa.states) == 3
+    @test length(not_equal_dfa.states) <= 3
   end
 
   @testset "RelationConstraint projection" begin
@@ -379,7 +370,7 @@ end
 
       for bits in all_bitstrings(sites)
         expected = Float64(is_feasible(collect(bits), constraint))
-        @test mpo_diagonal(H, sites, bits) ≈ expected
+        @test mpo_diagonal(H, sites, bits) ≈ expected atol=1e-8
       end
     end
 
@@ -406,7 +397,7 @@ end
 
     for rhs in (1, 2, 4)
       # The bound holds and is reached for a moderate number of unit-weight items.
-      @test sumbond(collect(1:8), ones(Int, 8), rhs) == rhs + 2
+      @test sumbond(collect(1:8), ones(Int, 8), rhs) <= rhs + 2
       # Growing the item count does not grow the bond dimension ...
       @test sumbond(collect(1:16), ones(Int, 16), rhs) == sumbond(collect(1:8), ones(Int, 8), rhs)
     end

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -68,9 +68,9 @@ end
     NotEqualsConstraint([1, 3], [1, 0]),
     NotEqualsConstraint([1, 2], [1.0, 0.0]),
     NotEqualsConstraint([1, 3, 2, 4], Bool[1, 0, 0, 1]),
-    ExactlyOneConstraint([1, 2, 3], 1),
-    ExactlyOneConstraint([1, 2, 3], 0),
-    ExactlyOneConstraint([2, 4, 3], 0),
+    AssignmentConstraint([1, 2, 3], [1], :(==), 1),
+    AssignmentConstraint([1, 2, 3], [0], :(==), 1),
+    AssignmentConstraint([2, 4, 3], [0], :(==), 1),
     RelationConstraint(4, :(<=), 2),
   ]
 
@@ -150,7 +150,7 @@ end
 
     constraints = AbstractConstraint[
       NotEqualsConstraint([1, 2], [1, 1]),
-      ExactlyOneConstraint([1, 3], 0),
+      AssignmentConstraint([1, 3], [0], :(==), 1),
     ]
     projections = TenSolver.projection_mpos(constraints, sites; domain = 0:1)
 
@@ -278,24 +278,19 @@ end
     end
   end
 
-  @testset "ExactlyOneConstraint projection" begin
+  @testset "AssignmentConstraint projection" begin
     cases = [
-      (ExactlyOneConstraint(1:2, 1), ITensors.siteinds("Qudit", 2; dim=2)),
-      (ExactlyOneConstraint(1:3, 0), ITensors.siteinds("Qudit", 3; dim=2)),
-      (ExactlyOneConstraint(1:5, 1), ITensors.siteinds("Qudit", 5; dim=2)),
+      (AssignmentConstraint(1:2, [1], :(==), 1), ITensors.siteinds("Qudit", 2; dim=2)),
+      (AssignmentConstraint(1:3, [0], :(==), 1), ITensors.siteinds("Qudit", 3; dim=2)),
+      (AssignmentConstraint(1:5, [1], :(==), 1), ITensors.siteinds("Qudit", 5; dim=2)),
     ]
 
     for (constraint, sites) in cases
       dfa = @inferred TenSolver.constraint_to_dfa(constraint, length(sites), 0:1)
-      @test length(dfa.states) == 2
-
-      for bits in all_bitstrings(sites)
-        target_hits = count(==(constraint.value), bits)
-        @test dfa_accepts(dfa, bits) == (target_hits == 1)
-      end
+      @test_broken length(dfa.states) == 2
 
       H = assert_projection_matches_feasibility(constraint, sites)
-      @test ITensorMPS.maxlinkdim(H) <= 2
+      @test_broken ITensorMPS.maxlinkdim(H) <= 2
     end
   end
 
@@ -321,15 +316,15 @@ end
     end
   end
 
-  @testset "ExactlyOneConstraint projection" begin
+  @testset "AssignmentConstraint projection" begin
     sites = ITensors.siteinds("Qudit", 4; dim=2)
 
-    exact_one = ExactlyOneConstraint([1, 3], 1)
+    exact_one = AssignmentConstraint([1, 3], [1], :(>=), 1)
     dfa = TenSolver.constraint_to_dfa(exact_one, length(sites),  0:1)
     H = assert_projection_matches_feasibility(exact_one, sites)
 
-    @test length(dfa.states) == 2
-    @test ITensorMPS.maxlinkdim(H) <= 2
+    @test_broken length(dfa.states) == 2
+    @test_broken ITensorMPS.maxlinkdim(H) <= 2
   end
 
   @testset "SumConstraint floating-point lowering" begin


### PR DESCRIPTION
Assignment constraints enforce

    count(x[s] in G for s in sites) rel rhs

They generalize exactly-one constraints as

    ExactlyOne(sites, v) = AssignmentConstraint(sites, [v], :(==), 1)

The required number of states is `rhs + 2`.

# Intentional Changes

- Use a uniform amount of states independent of relation. Per #117, all state-pruning happens at the MPO construction.
- Test for maximum bounds and not exact equality on bond dimension.
- Do not branch on automata construction.


