### PR TITLE
Implement modular sum constraint

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -49,6 +49,7 @@ for a worked example.
 ```@docs
 TenSolver.AbstractConstraint
 TenSolver.SumConstraint
+TenSolver.SumModConstraint
 TenSolver.NotEqualsConstraint
 TenSolver.AssignmentConstraint
 TenSolver.RelationConstraint

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -39,7 +39,7 @@ the effective Hamiltonian has bond dimension bounded by
 | Constraint | Enforces | Bond dimension of ``P`` |
 |:-----------|:---------|:------------------------|
 | [`SumConstraint`](@ref) | ``\sum_i w_i \, x_{s_i} \lessgtr b`` | ``b + 2`` (independent of the number of variables) |
-| [`SumModConstraint`](@ref) | ``\sum_i w_i \, x_{s_i} = b mod m`` | ``m`` |
+| [`SumModConstraint`](@ref) | ``\sum_i w_i \, x_{s_i} \equiv b \pmod m`` | ``m`` |
 | [`NotEqualsConstraint`](@ref) | ``x_S \ne v`` (one forbidden assignment) | 2 |
 | [`AssignmentConstraint`](@ref) | ``\mathrm{count}_{i \in S}(x_i \in G) \lessgtr b`` | ``b + 2`` |
 | [`RelationConstraint`](@ref) | ``x_i \lessgtr x_j`` | 2 |
@@ -107,11 +107,14 @@ so the projection bond dimension is `rhs + 2` regardless of how many variables t
 
 ```math
 \sum_{i \in \texttt{sites}} \texttt{weights}[i] \cdot x[i]
-\;\; == \;\; \texttt{rhs} \;\;\mathrm{mod}\;\; m,
+\equiv \texttt{rhs} \pmod m,
 ```
 
 The `sites` are unique positive integers representing variable indices,
-while `weights` and `rhs` must be **integers**.
+while `weights` and `rhs` must be **integers** and may be negative.
+The modulus `m` must be a positive integer.
+Weights and the rhs are normalized to their least nonnegative residues modulo `m`,
+and variable domains may contain any integer values.
 
 Its MPO tracks a partial sum with bond dimension `m`.
 

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -39,6 +39,7 @@ the effective Hamiltonian has bond dimension bounded by
 | Constraint | Enforces | Bond dimension of ``P`` |
 |:-----------|:---------|:------------------------|
 | [`SumConstraint`](@ref) | ``\sum_i w_i \, x_{s_i} \lessgtr b`` | ``b + 2`` (independent of the number of variables) |
+| [`SumModConstraint`](@ref) | ``\sum_i w_i \, x_{s_i} = b mod m`` | ``m`` |
 | [`NotEqualsConstraint`](@ref) | ``x_S \ne v`` (one forbidden assignment) | 2 |
 | [`AssignmentConstraint`](@ref) | ``\mathrm{count}_{i \in S}(x_i \in G) \lessgtr b`` | ``b + 2`` |
 | [`RelationConstraint`](@ref) | ``x_i \lessgtr x_j`` | 2 |
@@ -99,6 +100,20 @@ when the variable domains are nonnegative integers.
 
 Its automaton tracks a capped partial sum,
 so the projection bond dimension is `rhs + 2` regardless of how many variables the sum touches.
+
+### Modular Sum Constraint
+
+`SumModConstraint(sites, weights, rhs; mod = m)` enforces the weighted sum
+
+```math
+\sum_{i \in \texttt{sites}} \texttt{weights}[i] \cdot x[i]
+\;\; == \;\; \texttt{rhs} \;\;\mathrm{mod}\;\; m,
+```
+
+The `sites` are unique positive integers representing variable indices,
+while `weights` and `rhs` must be **integers**.
+
+Its MPO tracks a partial sum with bond dimension `m`.
 
 ### NotEqualsConstraint
 

--- a/src/TenSolver.jl
+++ b/src/TenSolver.jl
@@ -14,7 +14,7 @@ export bool_to_spin, spin_to_bool, qubo_to_ising, ising_to_qubo
 
 include("constraints.jl")
 export AbstractConstraint
-export SumConstraint, NotEqualsConstraint, AssignmentConstraint, RelationConstraint
+export SumConstraint, SumModConstraint, NotEqualsConstraint, AssignmentConstraint, RelationConstraint
 export is_feasible
 
 include("projection_mpo.jl")

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -41,7 +41,7 @@ struct SumConstraint{T<:Real} <: AbstractConstraint
   relation::Symbol
   rhs::T
 
-  function SumConstraint{T}(sites, weights, relation, rhs::T) where {T<:Real}
+  function SumConstraint{T}(sites, weights, relation, rhs) where {T<:Real}
     site_vec   = validate_sites(sites)
     weight_vec = validate_weights(weights)
     validate_same_length(site_vec, weight_vec, "sites", "weights")
@@ -55,17 +55,10 @@ struct SumConstraint{T<:Real} <: AbstractConstraint
 end
 
 function SumConstraint(sites, weights, relation, rhs)
-  raw_weights = collect(weights)
-  isempty(raw_weights) && throw(ArgumentError("weights must not be empty"))
-
-  weight_types = map(typeof, raw_weights)
+  weight_types = map(typeof, weights)
   T = promote_type(weight_types..., typeof(rhs))
 
-  weight_vec = T.(raw_weights)
-  rhs_value = convert(T, rhs)
-
-  # `sites` and `relation` are validated once, inside the inner constructor.
-  return SumConstraint{T}(sites, weight_vec, relation, rhs_value)
+  return SumConstraint{T}(sites, weights, relation, rhs)
 end
 
 function SumConstraint(sites, weights, rhs; relation)
@@ -108,12 +101,9 @@ struct SumModConstraint{T<:Real} <: AbstractConstraint
 end
 
 function SumModConstraint(sites, weights, rhs; mod)
-  raw_weights = collect(weights)
-  isempty(raw_weights) && throw(ArgumentError("weights must not be empty"))
+  T = promote_type(map(typeof, weights)..., typeof(rhs), typeof(mod))
 
-  T = promote_type(map(typeof, raw_weights)..., typeof(rhs), typeof(mod))
-
-  return SumModConstraint{T}(sites, T.(raw_weights), convert(T, rhs); mod=convert(T, mod))
+  return SumModConstraint{T}(sites, T.(weights), convert(T, rhs); mod=convert(T, mod))
 end
 
 """
@@ -219,10 +209,7 @@ function is_feasible(x::AbstractVector, constraint::SumConstraint)
 end
 
 function is_feasible(x::AbstractVector, constraint::SumModConstraint)
-  lhs = Base.mod(
-    sum(weight * x[site] for (site, weight) in constraint.weights),
-    constraint.mod,
-  )
+  lhs = mod(sum(w * x[s] for (s, w) in constraint.weights), constraint.mod)
   return lhs == constraint.rhs
 end
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -16,7 +16,7 @@ Constraint types are experimental. They currently provide TenSolver's
 Julia lowering target for projection-MPO constrained solves; future JuMP/MOI
 integration may change which constraint abstraction is considered stable public API.
 
-See also [`SumConstraint`](@ref), [`NotEqualsConstraint`](@ref),
+See also [`SumConstraint`](@ref), [`SumModConstraint`](@ref), [`NotEqualsConstraint`](@ref),
 [`AssignmentConstraint`](@ref), and [`RelationConstraint`](@ref).
 """
 abstract type AbstractConstraint end
@@ -70,6 +70,38 @@ end
 
 function SumConstraint(sites, weights, rhs; relation)
   return SumConstraint(sites, weights, relation, rhs)
+end
+
+"""
+    SumModConstraint{T} <: AbstractConstraint
+    SumModConstraint(sites, weights, rhs; mod)
+
+Modular weighted-sum constraint over a vector `x`:
+
+    ( sum(weights' * x[sites]) == rhs ) mod m.
+
+`sites` must be unique positive integers,
+`weights` must be the same length as `sites`.
+"""
+struct SumModConstraint{T<:Real} <: AbstractConstraint
+  weights::Dict{Int,T}
+  rhs::T
+  mod::T
+
+  function SumModConstraint{T}(sites, weights, rhs; mod) where {T<:Real}
+    site_vec   = validate_sites(sites)
+    weight_vec = validate_weights(map(w -> w % mod, weights))
+    rhs        = validate_rhs(rhs % mod)
+    validate_same_length(site_vec, weight_vec, "sites", "weights")
+
+    weight_map = Dict{Int,T}(zip(site_vec, weight_vec))
+
+    return new{T}(weight_map, rhs, mod)
+  end
+end
+
+function SumModConstraint(sites, weights, rhs; mod)
+  return SumModConstraint{typeof(mod)}(sites, weights, rhs; mod)
 end
 
 """
@@ -174,6 +206,11 @@ function is_feasible(x::AbstractVector, constraint::SumConstraint)
   return relation_holds(lhs, constraint.relation, constraint.rhs)
 end
 
+function is_feasible(x::AbstractVector, constraint::SumModConstraint)
+  lhs = sum(weight * x[site] for (site, weight) in constraint.weights) % constraint.mod
+  return lhs == constraint.rhs
+end
+
 function is_feasible(x::AbstractVector, constraint::NotEqualsConstraint)
   return any(x[site] != value for (site, value) in constraint.values)
 end
@@ -209,6 +246,10 @@ Access the site indices stored in the `constraint`.
 function constraint_sites end
 
 function constraint_sites(constraint::SumConstraint)
+  return keys(constraint.weights)
+end
+
+function constraint_sites(constraint::SumModConstraint)
   return keys(constraint.weights)
 end
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -78,10 +78,14 @@ end
 
 Modular weighted-sum constraint over a vector `x`:
 
-    ( sum(weights' * x[sites]) == rhs ) mod m.
+    sum(weights[i] * x[sites[i]] for i in eachindex(sites)) ≡ rhs (mod m).
 
 `sites` must be unique positive integers,
-`weights` must be the same length as `sites`.
+`weights` must be the same length as `sites`,
+`weights` and `rhs` must be integer-valued,
+and `mod` must be a positive integer.
+
+Weights and the rhs are stored as their least nonnegative residues modulo `mod`.
 """
 struct SumModConstraint{T<:Real} <: AbstractConstraint
   weights::Dict{Int,T}
@@ -89,19 +93,27 @@ struct SumModConstraint{T<:Real} <: AbstractConstraint
   mod::T
 
   function SumModConstraint{T}(sites, weights, rhs; mod) where {T<:Real}
-    site_vec   = validate_sites(sites)
-    weight_vec = validate_weights(map(w -> w % mod, weights))
-    rhs        = validate_rhs(rhs % mod)
-    validate_same_length(site_vec, weight_vec, "sites", "weights")
+    site_vec    = validate_sites(sites)
+    raw_weights = validate_integer_values(collect(weights), "weights")
+    validate_same_length(site_vec, raw_weights, "sites", "weights")
+    modulus = validate_modulus(mod)
+    raw_rhs = validate_integer_value(rhs, "rhs")
 
-    weight_map = Dict{Int,T}(zip(site_vec, weight_vec))
+    weight_vec     = Base.mod.(raw_weights, modulus)
+    normalized_rhs = Base.mod(raw_rhs, modulus)
+    weight_map     = Dict{Int,T}(zip(site_vec, weight_vec))
 
-    return new{T}(weight_map, rhs, mod)
+    return new{T}(weight_map, normalized_rhs, modulus)
   end
 end
 
 function SumModConstraint(sites, weights, rhs; mod)
-  return SumModConstraint{typeof(mod)}(sites, weights, rhs; mod)
+  raw_weights = collect(weights)
+  isempty(raw_weights) && throw(ArgumentError("weights must not be empty"))
+
+  T = promote_type(map(typeof, raw_weights)..., typeof(rhs), typeof(mod))
+
+  return SumModConstraint{T}(sites, T.(raw_weights), convert(T, rhs); mod=convert(T, mod))
 end
 
 """
@@ -207,7 +219,10 @@ function is_feasible(x::AbstractVector, constraint::SumConstraint)
 end
 
 function is_feasible(x::AbstractVector, constraint::SumModConstraint)
-  lhs = sum(weight * x[site] for (site, weight) in constraint.weights) % constraint.mod
+  lhs = Base.mod(
+    sum(weight * x[site] for (site, weight) in constraint.weights),
+    constraint.mod,
+  )
   return lhs == constraint.rhs
 end
 
@@ -321,6 +336,31 @@ function validate_weights(weights)
   end
 
   return weights
+end
+
+function validate_integer_value(value, name)
+  if !isinteger(value)
+    throw(ArgumentError("Found noninteger $name = $(repr(value)). $name must be integer."))
+  end
+
+  return value
+end
+
+function validate_integer_values(values, name)
+  isempty(values) && throw(ArgumentError("$name must not be empty"))
+
+  for (i, value) in enumerate(values)
+    validate_integer_value(value, "$name[$(i)]")
+  end
+
+  return values
+end
+
+function validate_modulus(modulus)
+  validate_integer_value(modulus, "mod")
+  modulus >= 1 || throw(ArgumentError("mod must be a positive integer"))
+
+  return modulus
 end
 
 function validate_rhs(rhs)

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -232,6 +232,8 @@ Constraint site numbers use the same 1-based register indexing as `sites`.
 
 - [`SumConstraint`](@ref) uses a exact integer partial-sum automaton.
   For a constraint with rhs `k`, its maximum bond dimension is `k+2`.
+- [`SumModConstraint`](@ref) uses a modular partial-sum automaton.
+  Its maximum bond dimension is the remainder modulo `m`.
 - [`NotEqualsConstraint`](@ref) uses a MPO with bond dimension `2`,
   independently of the rhs.
 - [`AssignmentConstraint`](@ref) uses a membership counting automaton.
@@ -386,6 +388,27 @@ function constraint_to_dfa(constraint::SumConstraint{S}, nsites::Integer, alphab
   for site in constraint_sites(constraint)
     transitions[site] = Dict(
       (q, a) => min(q + weights[site] * a, beyond)
+      for q in states, a in alphabet
+    )
+  end
+
+  return DFA(states, alphabet, initial, accepting, transitions)
+end
+
+function constraint_to_dfa(constraint::SumModConstraint{S}, nsites::Integer, alphabet) where {S}
+  (; weights, rhs, mod) = constraint
+
+  states    = zero(S):(mod-1)
+  initial   = zero(S)
+  accepting = Set(rhs)
+
+  id_dict = Dict((q, a) => q for q in states for a in alphabet)
+  transitions = fill(id_dict, nsites)
+
+  f(site, a) = weights[site] * a
+  for site in constraint_sites(constraint)
+    transitions[site] = Dict(
+      (q, a) => rem(q + f(site, a), mod)
       for q in states, a in alphabet
     )
   end

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -233,7 +233,7 @@ Constraint site numbers use the same 1-based register indexing as `sites`.
 - [`SumConstraint`](@ref) uses a exact integer partial-sum automaton.
   For a constraint with rhs `k`, its maximum bond dimension is `k+2`.
 - [`SumModConstraint`](@ref) uses a modular partial-sum automaton.
-  Its maximum bond dimension is the remainder modulo `m`.
+  Its `m` residue states give it bond dimension `m`.
 - [`NotEqualsConstraint`](@ref) uses a MPO with bond dimension `2`,
   independently of the rhs.
 - [`AssignmentConstraint`](@ref) uses a membership counting automaton.
@@ -396,19 +396,23 @@ function constraint_to_dfa(constraint::SumConstraint{S}, nsites::Integer, alphab
 end
 
 function constraint_to_dfa(constraint::SumModConstraint{S}, nsites::Integer, alphabet) where {S}
-  (; weights, rhs, mod) = constraint
+  if !all(isinteger, alphabet)
+    throw(ArgumentError("SumModConstraint only supports integer domains."))
+  end
 
-  states    = zero(S):(mod-1)
+  (; weights, rhs) = constraint
+  modulus = constraint.mod
+
+  states    = zero(S):(modulus-one(S))
   initial   = zero(S)
   accepting = Set(rhs)
 
   id_dict = Dict((q, a) => q for q in states for a in alphabet)
   transitions = fill(id_dict, nsites)
 
-  f(site, a) = weights[site] * a
   for site in constraint_sites(constraint)
     transitions[site] = Dict(
-      (q, a) => rem(q + f(site, a), mod)
+      (q, a) => Base.mod(q + weights[site] * a, modulus)
       for q in states, a in alphabet
     )
   end

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -412,7 +412,7 @@ function constraint_to_dfa(constraint::SumModConstraint{S}, nsites::Integer, alp
 
   for site in constraint_sites(constraint)
     transitions[site] = Dict(
-      (q, a) => Base.mod(q + weights[site] * a, modulus)
+      (q, a) => mod(q + weights[site] * a, modulus)
       for q in states, a in alphabet
     )
   end

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -12,6 +12,14 @@
     @test keyword_sum.weights == Dict(1 => 1.0, 2 => 5.0)
     @test keyword_sum.rhs == 2.0
 
+    sum_mod = SumModConstraint([1, 3], [-1, 4], -2; mod = 3)
+    @test sum_mod isa SumModConstraint{Int}
+    @test sum_mod isa AbstractConstraint
+    @test Set(TenSolver.constraint_sites(sum_mod)) == Set([1, 3])
+    @test sum_mod.weights == Dict(1 => 2, 3 => 1)
+    @test sum_mod.rhs == 1
+    @test sum_mod.mod == 3
+
     not_equals = NotEqualsConstraint([1, 2], [1, 0])
     @test not_equals isa NotEqualsConstraint{Int}
     @test Set(TenSolver.constraint_sites(not_equals)) == Set([1, 2])
@@ -67,6 +75,13 @@
     @test_throws ArgumentError SumConstraint([1], [1], "==", 0)
     @test_throws UndefKeywordError SumConstraint([1, 2], [1, 1], 1)
 
+    @test_throws DimensionMismatch SumModConstraint([1, 2], [1], 0; mod = 2)
+    @test_throws ArgumentError SumModConstraint([1], [1.5], 0; mod = 2)
+    @test_throws ArgumentError SumModConstraint([1], [1], 0.5; mod = 2)
+    @test_throws ArgumentError SumModConstraint([1], [1], 0; mod = 0)
+    @test_throws ArgumentError SumModConstraint([1], [1], 0; mod = -2)
+    @test_throws ArgumentError SumModConstraint([1], [1], 0; mod = 2.5)
+
     @testset "SumConstraint floating-point validation" begin
       @test SumConstraint([1, 2], [1.0, 2.0], 2.0; relation=:(<=)) isa SumConstraint
       @test SumConstraint([1, 2], [1.0, 1.0], 1.0; relation=:(==)) isa SumConstraint
@@ -97,6 +112,10 @@
     sum_mod = SumModConstraint([1, 2], [1, 1], 1; mod=2)
     @test  is_feasible([1, 0], sum_mod)
     @test !is_feasible([1, 1], sum_mod)
+
+    signed_sum_mod = SumModConstraint([1], [-1], -1; mod = 3)
+    @test is_feasible([1], signed_sum_mod)
+    @test is_feasible([-1], SumModConstraint([1], [1], 2; mod = 3))
 
     not_equals = NotEqualsConstraint([1, 3], [1, 0])
     @test !is_feasible([1, 1, 0], not_equals)

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -94,6 +94,10 @@
     @test is_feasible([1, 0], sum_eq)
     @test !is_feasible([1, 1], sum_eq)
 
+    sum_mod = SumModConstraint([1, 2], [1, 1], 1; mod=2)
+    @test  is_feasible([1, 0], sum_mod)
+    @test !is_feasible([1, 1], sum_mod)
+
     not_equals = NotEqualsConstraint([1, 3], [1, 0])
     @test !is_feasible([1, 1, 0], not_equals)
     @test is_feasible([1, 1, 1], not_equals)

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -66,6 +66,7 @@ end
     SumConstraint([1, 2, 4], [1, 2, 3], :(==), 3),
     SumConstraint([2, 4], [2, 3], :(>=), 3),
     SumConstraint([1, 2, 4], [1, 2, 3], :(!=), 3),
+    SumModConstraint([1, 2, 4], [1, 2, 3], 3; mod = 3),
     NotEqualsConstraint([1, 3], [1, 0]),
     NotEqualsConstraint([1, 2], [1.0, 0.0]),
     NotEqualsConstraint([1, 3, 2, 4], Bool[1, 0, 0, 1]),
@@ -347,6 +348,17 @@ end
       H = assert_projection_matches_feasibility(constraint, sites)
       @test ITensorMPS.maxlinkdim(H) <= 2
     end
+  end
+
+  @testset "SumModConstraint projection" begin
+    sites = ITensors.siteinds("Qudit", 4; dim=2)
+
+    constraint = SumModConstraint([1, 3], [1, 2], 0 ; mod = 3)
+    dfa = TenSolver.constraint_to_dfa(constraint, length(sites),  0:1)
+    H = assert_projection_matches_feasibility(constraint, sites)
+
+    @test length(dfa.states) == 3
+    @test ITensorMPS.maxlinkdim(H) <= 3
   end
 
   @testset "SumConstraint floating-point lowering" begin

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -14,7 +14,8 @@ function assert_projection_matches_feasibility(constraint, sites; domain = 0:1)
   assignments = Iterators.product(fill(domain, length(sites))...)
   for assignment in assignments
     expected = Float64(is_feasible(collect(assignment), constraint))
-    @test mpo_diagonal(H, sites, assignment) ≈ expected atol=sqrt(eps(Float64))
+    basis_values = map(value -> findfirst(==(value), domain) - 1, assignment)
+    @test mpo_diagonal(H, sites, basis_values) ≈ expected atol=sqrt(eps(Float64))
   end
 
   return H
@@ -358,8 +359,8 @@ end
     dfa = TenSolver.constraint_to_dfa(constraint, length(sites), domain)
     H = assert_projection_matches_feasibility(constraint, sites; domain)
 
-    @test length(dfa.states) == 3
-    @test ITensorMPS.maxlinkdim(H) == constraint.mod
+    @test length(dfa.states) <= 3
+    @test ITensorMPS.maxlinkdim(H) <= constraint.mod
     @test_throws ArgumentError TenSolver.constraint_to_dfa(constraint, length(sites), [0, 0.5])
   end
 

--- a/test/projection_mpo.jl
+++ b/test/projection_mpo.jl
@@ -351,14 +351,16 @@ end
   end
 
   @testset "SumModConstraint projection" begin
-    sites = ITensors.siteinds("Qudit", 4; dim=2)
+    domain = -1:1
+    sites = ITensors.siteinds("Qudit", 4; dim=length(domain))
 
-    constraint = SumModConstraint([1, 3], [1, 2], 0 ; mod = 3)
-    dfa = TenSolver.constraint_to_dfa(constraint, length(sites),  0:1)
-    H = assert_projection_matches_feasibility(constraint, sites)
+    constraint = SumModConstraint([1, 3], [-1, 2], -1; mod = 3)
+    dfa = TenSolver.constraint_to_dfa(constraint, length(sites), domain)
+    H = assert_projection_matches_feasibility(constraint, sites; domain)
 
     @test length(dfa.states) == 3
-    @test ITensorMPS.maxlinkdim(H) <= 3
+    @test ITensorMPS.maxlinkdim(H) == constraint.mod
+    @test_throws ArgumentError TenSolver.constraint_to_dfa(constraint, length(sites), [0, 0.5])
   end
 
   @testset "SumConstraint floating-point lowering" begin


### PR DESCRIPTION
`SumModConstraint` with feasibility set satisfying

    sum(w[i] * x[i] for i in sites) == k mod m

This constraint is a new addition that is explicitly absent from the CoTenN paper.

Closes #95.