### PR TITLE
Release version v0.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TenSolver"
 uuid = "cfd60579-01bf-4b47-9b3b-7c8dc91a23e2"
 authors = ["Iago Leal de Freitas <iago@iagoleal.com>", "David E. Bernal Neira <dbernaln@purdue.edu>"]
-version = "0.2.3"
+version = "0.3.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/benchmarks/Project.toml
+++ b/benchmarks/Project.toml
@@ -7,5 +7,4 @@ TenSolver = "cfd60579-01bf-4b47-9b3b-7c8dc91a23e2"
 
 [compat]
 BenchmarkTools = "1"
-TenSolver = "0.2"
 julia = "1.10"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -11,4 +11,3 @@ TenSolver = {path = ".."}
 Documenter = "1.17.0"
 DynamicPolynomials = "0.6.6"
 JuMP = "1.30.1"
-TenSolver = "0.2.0"


### PR DESCRIPTION
New released version containing general variable domains and v1 constrained programming API.

Merging this should close #55.

This PR **intentionally** removes the TenSolver compatibility fields from `docs/Project.toml` and `benchmarks/Project.toml` since those are assumed to only run against the repository HEAD. A repository package should not impose compatibility issues against itself.