### PR TITLE
Support noncommuting Hamiltonian projections

### DIFF
--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -26,18 +26,23 @@ A solve with `constraints` proceeds in three steps:
    accepts exactly the feasible vectors, and the automaton is threaded into
    an MPO ``P`` that is **diagonal with entries 1 on feasible basis states and
    0 on infeasible ones** — an exact projector, not a penalty.
-3. DMRG minimizes the projected Hamiltonian ``P' H P``. Because numerical noise
-   and truncation can leak amplitude back into the (zero-energy) infeasible
-   kernel, the state is re-projected at every iteration, which is what makes
-   every sampled solution feasible.
+3. DMRG minimizes the projected Hamiltonian ``P' H P``. The objective and
+   built-in projectors are diagonal, and each projector is Hermitian and
+   idempotent, so TenSolver constructs this as the equivalent one-sided product
+   ``H P``. Because numerical noise and truncation can leak amplitude back into
+   the (zero-energy) infeasible kernel, the state is re-projected at every
+   iteration, which is what makes every sampled solution feasible.
 
 Each of the four built-in constraint types has a specialized automaton with a
 compact bond dimension (see the table below).
 
 
-The cost driver is the MPO bond dimension: the projected Hamiltonian satisfies
-``\chi(P' H P) \le \chi(H) \cdot \prod_i \chi(P_i)^2``, so compact projections
-keep constrained solves close to the unconstrained cost.
+The cost driver is the MPO bond dimension. For TenSolver's commuting objective
+and projectors, the one-sided construction satisfies
+``\chi(H P) \le \chi(H) \cdot \prod_i \chi(P_i)``. The general
+``P' H P`` construction remains available through
+[`TenSolver.project_hamiltonian`](@ref) with `formulation=:sandwich`; its bound is
+``\chi(H) \cdot \prod_i \chi(P_i)^2``.
 
 | Constraint | Enforces | Bond dimension of ``P`` |
 |:-----------|:---------|:------------------------|

--- a/docs/src/constraints.md
+++ b/docs/src/constraints.md
@@ -24,25 +24,17 @@ A solve with `constraints` proceeds in three steps:
    unconstrained case.
 2. Each constraint is lowered to a deterministic finite automaton (DFA) that
    accepts exactly the feasible vectors, and the automaton is threaded into
-   an MPO ``P`` that is **diagonal with entries 1 on feasible basis states and
-   0 on infeasible ones** — an exact projector, not a penalty.
-3. DMRG minimizes the projected Hamiltonian ``P' H P``. The objective and
-   built-in projectors are diagonal, and each projector is Hermitian and
-   idempotent, so TenSolver constructs this as the equivalent one-sided product
-   ``H P``. Because numerical noise and truncation can leak amplitude back into
-   the (zero-energy) infeasible kernel, the state is re-projected at every
-   iteration, which is what makes every sampled solution feasible.
+   an MPO ``P`` that is *diagonal with entries 1 on feasible basis states and
+   0 on infeasible ones*.
+3. DMRG minimizes the projected Hamiltonian ``P' H P``,
+   or some semantically equivalent context-dependent MPO.
+
 
 Each of the four built-in constraint types has a specialized automaton with a
 compact bond dimension (see the table below).
-
-
-The cost driver is the MPO bond dimension. For TenSolver's commuting objective
-and projectors, the one-sided construction satisfies
-``\chi(H P) \le \chi(H) \cdot \prod_i \chi(P_i)``. The general
-``P' H P`` construction remains available through
-[`TenSolver.project_hamiltonian`](@ref) with `formulation=:sandwich`; its bound is
-``\chi(H) \cdot \prod_i \chi(P_i)^2``.
+For TenSolver's current implementation,
+the effective Hamiltonian has bond dimension bounded by
+``\chi(P' H P) \le \chi(H) \cdot \prod_i \chi(P_i)``.
 
 | Constraint | Enforces | Bond dimension of ``P`` |
 |:-----------|:---------|:------------------------|

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -276,11 +276,11 @@ projection_mpos(constraints::AbstractVector{<:AbstractConstraint}, sites; kws...
 Project a Hamiltonian MPO with one or more projection MPOs.
 
 If `Q = P₁ * ⋯ * Pₙ` is the combined projector, the effective Hamiltonian has
-the CoTenN semantics `Q' * H * Q`.
+the semantics `Q' * H * Q`.
 
 With the default `formulation=:commuting`, `H` and all `Pᵢ` must be mutually
-commuting, while each `Pᵢ` must be Hermitian and idempotent. The construction
-then simplifies to `H * Q`, with bond dimension bounded by the product of `H`'s
+commuting, while each `Pᵢ` must an orthogonal projection (Hermitian and idempotent).
+The construction then simplifies to `H * Q`, with bond dimension bounded by the product of `H`'s
 links and each projection link. TenSolver's objective and constraint MPOs
 satisfy these assumptions because they are diagonal.
 
@@ -292,29 +292,23 @@ function project_hamiltonian(
   H::ITensorMPS.MPO,
   projections;
   formulation = :commuting,
-  cutoff = 1e-8,
   kwargs...,
 )
   projection_tuple = projection_sequence(projections)
-  target_sites = projection_target_sites(H)
+  target_sites     = projection_target_sites(H)
   validate_projection_sequence(target_sites, projection_tuple)
 
-  op = (x, y) -> ITensors.apply(x, y; cutoff, kwargs...)
+  op = (x, y) -> ITensors.apply(x, y; kwargs...)
   if formulation === :commuting
+    # TODO: We should profile and check that this simplification actually speeds up the code.
     return reduce(op, projection_tuple; init = H)
+  elseif formulation === :sandwich
+    op2(h, p) = op(ITensors.dag(p), op(h, p))
+    return reduce(op2, projection_tuple; init = H)
+  else
+    msg = "formulation must be :commuting or :sandwich; got $(repr(formulation))"
+    throw(ArgumentError(msg))
   end
-
-  if formulation === :sandwich
-    H_eff = H
-    for P in projection_tuple
-      H_eff = op(ITensors.dag(P), H_eff)
-      H_eff = op(H_eff, P)
-    end
-    return H_eff
-  end
-
-  msg = "formulation must be :commuting or :sandwich; got $(repr(formulation))"
-  throw(ArgumentError(msg))
 end
 
 """

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -271,27 +271,50 @@ projection_mpos(constraints::AbstractVector{<:AbstractConstraint}, sites; kws...
   projection_mpos(Float64, constraints, sites; kws...)
 
 """
-    project_hamiltonian(H, projections; cutoff=1e-8, kwargs...)
+    project_hamiltonian(H, projections; formulation=:commuting, cutoff=1e-8, kwargs...)
 
-Apply one or more diagonal projection MPOs to a Hamiltonian MPO.
+Project a Hamiltonian MPO with one or more projection MPOs.
 
-For projection MPOs `P`, this builds the CoTenN-style effective Hamiltonian
-`P' * H * P`. The resulting bond dimension can grow with the product of
-`H`'s links and the projection links.
+If `Q = P₁ * ⋯ * Pₙ` is the combined projector, the effective Hamiltonian has
+the CoTenN semantics `Q' * H * Q`.
+
+With the default `formulation=:commuting`, `H` and all `Pᵢ` must be mutually
+commuting, while each `Pᵢ` must be Hermitian and idempotent. The construction
+then simplifies to `H * Q`, with bond dimension bounded by the product of `H`'s
+links and each projection link. TenSolver's objective and constraint MPOs
+satisfy these assumptions because they are diagonal.
+
+Use `formulation=:sandwich` for general, potentially noncommuting MPOs. It
+constructs `Q' * H * Q` directly, so each projection link contributes twice to
+the bond-dimension bound.
 """
-function project_hamiltonian(H::ITensorMPS.MPO, projections; cutoff=1e-8, kwargs...)
+function project_hamiltonian(
+  H::ITensorMPS.MPO,
+  projections;
+  formulation = :commuting,
+  cutoff = 1e-8,
+  kwargs...,
+)
   projection_tuple = projection_sequence(projections)
   target_sites = projection_target_sites(H)
   validate_projection_sequence(target_sites, projection_tuple)
 
-  # WARNING: The code below assumes that all MPOs are **diagonal**
-  # and all projections are actual projections, i.e. P^2 = P.
-  # It simplifies P'HP = PHP = HPP = HP.
-  # We should test that this simplification actually improves the code
-  # or if the MPO multiplication machinery already catchs it.
-  # We keep the documentation as P'HP _on purpose_ because that is the correct semantics.
   op = (x, y) -> ITensors.apply(x, y; cutoff, kwargs...)
-  return reduce(op, projection_tuple; init = H)
+  if formulation === :commuting
+    return reduce(op, projection_tuple; init = H)
+  end
+
+  if formulation === :sandwich
+    H_eff = H
+    for P in projection_tuple
+      H_eff = op(ITensors.dag(P), H_eff)
+      H_eff = op(H_eff, P)
+    end
+    return H_eff
+  end
+
+  msg = "formulation must be :commuting or :sandwich; got $(repr(formulation))"
+  throw(ArgumentError(msg))
 end
 
 """

--- a/test/project_hamiltonian.jl
+++ b/test/project_hamiltonian.jl
@@ -1,0 +1,81 @@
+import ITensors, ITensorMPS
+
+# All matrices and matrix elements in these formulation tests are dimensionless.
+function one_site_mpo(site, matrix)
+  tensor = ITensors.ITensor(eltype(matrix), ITensors.prime(site), site)
+  for row in axes(matrix, 1), column in axes(matrix, 2)
+    tensor[ITensors.prime(site) => row, site => column] = matrix[row, column]
+  end
+  return ITensorMPS.MPO([tensor])
+end
+
+function assert_mpo_matrix(H, sites, bitstrings, expected)
+  for (row, bra) in enumerate(bitstrings), (column, ket) in enumerate(bitstrings)
+    @test mpo_matrix_element(H, sites, bra, ket) ≈ expected[row, column]
+  end
+end
+
+@testset "Projected Hamiltonian formulations" begin
+  sites = ITensors.siteinds("Qudit", 1; dim = 2)
+  site = only(sites)
+  bitstrings = ((0,), (1,))
+
+  @testset "Commuting formulation remains the default" begin
+    H = one_site_mpo(site, [2.0 0.0; 0.0 -1.0])
+    P = one_site_mpo(site, [1.0 0.0; 0.0 0.0])
+
+    H_default = TenSolver.project_hamiltonian(H, P; cutoff = 1e-12)
+    H_commuting =
+      TenSolver.project_hamiltonian(H, P; formulation = :commuting, cutoff = 1e-12)
+    H_sandwich =
+      TenSolver.project_hamiltonian(H, P; formulation = :sandwich, cutoff = 1e-12)
+
+    expected = [2.0 0.0; 0.0 0.0]
+    assert_mpo_matrix(H_default, sites, bitstrings, expected)
+    assert_mpo_matrix(H_commuting, sites, bitstrings, expected)
+    assert_mpo_matrix(H_sandwich, sites, bitstrings, expected)
+  end
+
+  @testset "Sandwich formulation supports a noncommuting projector" begin
+    # H = |0><0| and P = |+><+| do not commute:
+    # HP = [1/2 1/2; 0 0], while P'HP = [1/4 1/4; 1/4 1/4].
+    H = one_site_mpo(site, [1.0 0.0; 0.0 0.0])
+    P = one_site_mpo(site, fill(0.5, 2, 2))
+
+    H_commuting =
+      TenSolver.project_hamiltonian(H, P; formulation = :commuting, cutoff = 1e-12)
+    H_sandwich =
+      TenSolver.project_hamiltonian(H, P; formulation = :sandwich, cutoff = 1e-12)
+
+    assert_mpo_matrix(H_commuting, sites, bitstrings, [0.5 0.5; 0.0 0.0])
+    assert_mpo_matrix(H_sandwich, sites, bitstrings, fill(0.25, 2, 2))
+  end
+
+  @testset "Sandwich formulation preserves projection order" begin
+    H = one_site_mpo(site, [1.0 0.0; 0.0 2.0])
+    P_zero = one_site_mpo(site, [1.0 0.0; 0.0 0.0])
+    P_plus = one_site_mpo(site, fill(0.5, 2, 2))
+
+    zero_then_plus = TenSolver.project_hamiltonian(
+      H,
+      (P_zero, P_plus);
+      formulation = :sandwich,
+      cutoff = 1e-12,
+    )
+    plus_then_zero = TenSolver.project_hamiltonian(
+      H,
+      (P_plus, P_zero);
+      formulation = :sandwich,
+      cutoff = 1e-12,
+    )
+
+    assert_mpo_matrix(zero_then_plus, sites, bitstrings, fill(0.25, 2, 2))
+    assert_mpo_matrix(plus_then_zero, sites, bitstrings, [0.75 0.0; 0.0 0.0])
+  end
+
+  @test_throws ArgumentError TenSolver.project_hamiltonian(
+    one_site_mpo(site, [1.0 0.0; 0.0 0.0]),
+    one_site_mpo(site, [1.0 0.0; 0.0 0.0]);
+    formulation = :unknown,
+  )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ include(filepath("ising_conversion.jl"))
 # Binary constraint API
 include(filepath("constraints.jl"))
 include(filepath("projection_mpo.jl"))
+include(filepath("project_hamiltonian.jl"))
 
 # MPO construction
 include(filepath("tensorize.jl"))


### PR DESCRIPTION
## Summary

- keep `formulation=:commuting` as the default one-sided `H * Q` construction
- add `formulation=:sandwich` for the general `Q' * H * Q` construction
- reject unknown formulations instead of forwarding and silently ignoring them
- document the commutation/projector assumptions and the linear versus quadratic bond bounds
- add dedicated regression coverage for commuting equivalence, a nondiagonal noncommuting projector, and multiple-projector ordering

Follow-up to #122.

## Acceptance criteria

- [x] TenSolver's default diagonal route retains the lower-cost commuting formulation.
- [x] General noncommuting projection MPOs can opt into the original sandwich formulation.
- [x] The public helper documents when each formulation is valid.
- [x] Tests distinguish `H * P` from `P' * H * P` and preserve projection order.

## Verification

- [x] `julia --project=. -e 'using Test, TenSolver; include("test/utils.jl"); include("test/project_hamiltonian.jl")'` — 29/29 passed
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — full suite passed on Julia 1.10.11
- [x] `julia --project=docs/ docs/make.jl local` — documentation built successfully
- [x] Red-on-base check at `7585275`: the pre-fix implementation produced five expected failures for the sandwich result and invalid-formulation validation

## Branch Hygiene

- Base: `main` at `7585275`
- Head: `fix/project-hamiltonian-formulations`
- Not stacked; #122 is already merged into the base.
- Open PRs #120 and #121 touch the same projection source/docs files in nonadjacent constraint-specific hunks. PR #116 touches `test/runtests.jl` near the documentation include, while this PR adds a test include near the constraint tests; no direct hunk overlap was found.
