### PR TITLE
Internal refactoring of constraints and MPO

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Iago Leal de Freitas <iago@iagoleal.com>", "David E. Bernal Neira <d
 version = "0.3.0"
 
 [deps]
+ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 ITensorMPS = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
@@ -15,6 +16,7 @@ QUBOTools = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
+ArgCheck = "2.5.0"
 Combinatorics = "1"
 ITensorMPS = "0.3, 0.4"
 ITensors = "0.9"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -82,6 +82,7 @@ TenSolver.preprocess_qubo
 ```@docs
 TenSolver.DFA
 TenSolver.constraint_to_dfa
+TenSolver.mapreduce_dfa
 TenSolver.dfa_to_mpo
 TenSolver.projection_mpo
 TenSolver.projection_mpos

--- a/src/TenSolver.jl
+++ b/src/TenSolver.jl
@@ -2,6 +2,7 @@ module TenSolver
 
 import ITensors, ITensorMPS
 using QUBODrivers: QUBODrivers, QUBOTools, MOI
+using ArgCheck: @argcheck
 
 using LinearAlgebra
 

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -105,9 +105,11 @@ struct SumModConstraint{T<:Integer} <: AbstractConstraint
     weights = T.(weights)
     rhs     = T(rhs)
     mod     = T(mod)
+    g       = gcd(mod, rhs, weights...)
 
-    @. weights = Base.mod(weights, mod)
-    rhs        = Base.mod(rhs, mod)
+    mod        = div(mod, g)
+    @. weights = Base.mod(div(weights, g), mod)
+    rhs        = Base.mod(div(rhs, g), mod)
 
     weight_map = Dict{Int,T}(zip(sites, weights))
     filter!(p -> !iszero(p.second), weight_map)

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -1,3 +1,6 @@
+integer(::Type{T}) where {T<:Integer} = T
+integer(::Type) = Int
+
 """
     AbstractConstraint
 
@@ -41,7 +44,7 @@ struct SumConstraint{T<:Integer} <: AbstractConstraint
   relation::Symbol
   rhs::T
 
-  function SumConstraint{T}(sites, weights, relation, rhs) where {T<:Real}
+  function SumConstraint{T}(sites, weights, relation, rhs) where {T<:Integer}
     site_vec   = validate_sites(sites)
     weight_vec = validate_weights(weights)
     validate_same_length(site_vec, weight_vec, "sites", "weights")
@@ -62,11 +65,8 @@ struct SumConstraint{T<:Integer} <: AbstractConstraint
   end
 end
 
-integer(::Type{T}) where {T<:Integer} = T
-integer(::Type) = Int
-
 function SumConstraint(sites, weights, relation, rhs)
-  T = integer(promote_type(typeof(rhs), valtype(weights)))
+  T = integer(promote_type(typeof(rhs), eltype(weights)))
   return SumConstraint{T}(sites, weights, relation, rhs)
 end
 
@@ -94,16 +94,14 @@ struct SumModConstraint{T<:Integer} <: AbstractConstraint
   rhs::T
   mod::T
 
-  function SumModConstraint{T}(sites, weights, rhs; mod) where {T<:Real}
+  function SumModConstraint{T}(sites, weights, rhs; mod) where {T<:Integer}
     site_vec    = validate_sites(sites)
-    raw_weights = validate_integer_values(collect(weights), "weights")
-    validate_same_length(site_vec, raw_weights, "sites", "weights")
+    validate_same_length(site_vec, weights, "sites", "weights")
     modulus     = validate_modulus(mod)
-    raw_rhs     = validate_integer_value(rhs, "rhs")
 
     modulus        = T(modulus)
-    weight_vec     = Base.mod.(T.(raw_weights), modulus)
-    normalized_rhs = Base.mod(T(raw_rhs), modulus)
+    weight_vec     = @. Base.mod(T(weights), modulus)
+    normalized_rhs = Base.mod(T(rhs), modulus)
 
     weight_map     = Dict{Int,T}(zip(site_vec, weight_vec))
     filter!(p -> !iszero(p.second), weight_map)
@@ -321,7 +319,7 @@ function validate_weights(weights)
   # by the constraint/MPO work tracked in #57. Signed weights (e.g. encoding a
   # difference `x1 - x2 == 0`) are intentionally out of scope here and should be
   # revisited together with that lowering, not relaxed in isolation.
-  for (i, weight) in enumerate(weights)
+  for (i, weight) in pairs(weights)
     if weight < 0
       throw(ArgumentError("Found negative weight w[$(i)] = $(repr(weight)). Weights must be nonnegative."))
     end
@@ -333,26 +331,7 @@ function validate_weights(weights)
   return weights
 end
 
-function validate_integer_value(value, name)
-  if !isinteger(value)
-    throw(ArgumentError("Found noninteger $name = $(repr(value)). $name must be integer."))
-  end
-
-  return value
-end
-
-function validate_integer_values(values, name)
-  isempty(values) && throw(ArgumentError("$name must not be empty"))
-
-  for (i, value) in enumerate(values)
-    validate_integer_value(value, "$name[$(i)]")
-  end
-
-  return values
-end
-
 function validate_modulus(modulus)
-  validate_integer_value(modulus, "mod")
   modulus >= 1 || throw(ArgumentError("mod must be a positive integer"))
 
   return modulus
@@ -362,16 +341,14 @@ function validate_rhs(rhs)
   if rhs < 0
     throw(ArgumentError("Found negative rhs = $(repr(rhs)). rhs must be nonnegative."))
   end
-  if !isinteger(rhs)
-    throw(ArgumentError("Found noninteger rhs = $(repr(rhs)). rhs must be integer."))
-  end
 
   return rhs
 end
 
 function validate_relation(relation)
-  relation in VALID_RELATIONS ||
+  if !(relation in VALID_RELATIONS)
     throw(ArgumentError("relation must be one of: $(join(string.(VALID_RELATIONS), ", "))"))
+  end
 
   return relation
 end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -36,7 +36,7 @@ and `relation` must be one of `:(==)`, `:(!=)`, `:(<=)`, or `:(>=)`.
 
 Warning: The `==` and `!=` relations use exact arithmetic comparison.
 """
-struct SumConstraint{T<:Real} <: AbstractConstraint
+struct SumConstraint{T<:Integer} <: AbstractConstraint
   weights::Dict{Int,T}
   relation::Symbol
   rhs::T
@@ -48,16 +48,25 @@ struct SumConstraint{T<:Real} <: AbstractConstraint
     relation   = validate_relation(relation)
     rhs        = validate_rhs(rhs)
 
+    weight_vec = T.(weight_vec)
+    rhs        = T(rhs)
+
+    g = gcd(rhs, weight_vec...)
+    weight_vec .= div.(weight_vec, g)
+    rhs         = div(rhs, g)
+
     weight_map = Dict{Int,T}(zip(site_vec, weight_vec))
+    filter!(p -> !iszero(p.second), weight_map)
 
     return new{T}(weight_map, relation, rhs)
   end
 end
 
-function SumConstraint(sites, weights, relation, rhs)
-  weight_types = map(typeof, weights)
-  T = promote_type(weight_types..., typeof(rhs))
+integer(::Type{T}) where {T<:Integer} = T
+integer(::Type) = Int
 
+function SumConstraint(sites, weights, relation, rhs)
+  T = integer(promote_type(typeof(rhs), valtype(weights)))
   return SumConstraint{T}(sites, weights, relation, rhs)
 end
 
@@ -80,7 +89,7 @@ and `mod` must be a positive integer.
 
 Weights and the rhs are stored as their least nonnegative residues modulo `mod`.
 """
-struct SumModConstraint{T<:Real} <: AbstractConstraint
+struct SumModConstraint{T<:Integer} <: AbstractConstraint
   weights::Dict{Int,T}
   rhs::T
   mod::T
@@ -89,20 +98,22 @@ struct SumModConstraint{T<:Real} <: AbstractConstraint
     site_vec    = validate_sites(sites)
     raw_weights = validate_integer_values(collect(weights), "weights")
     validate_same_length(site_vec, raw_weights, "sites", "weights")
-    modulus = validate_modulus(mod)
-    raw_rhs = validate_integer_value(rhs, "rhs")
+    modulus     = validate_modulus(mod)
+    raw_rhs     = validate_integer_value(rhs, "rhs")
 
-    weight_vec     = Base.mod.(raw_weights, modulus)
-    normalized_rhs = Base.mod(raw_rhs, modulus)
+    modulus        = T(modulus)
+    weight_vec     = Base.mod.(T.(raw_weights), modulus)
+    normalized_rhs = Base.mod(T(raw_rhs), modulus)
+
     weight_map     = Dict{Int,T}(zip(site_vec, weight_vec))
+    filter!(p -> !iszero(p.second), weight_map)
 
     return new{T}(weight_map, normalized_rhs, modulus)
   end
 end
 
 function SumModConstraint(sites, weights, rhs; mod)
-  T = promote_type(map(typeof, weights)..., typeof(rhs), typeof(mod))
-
+  T = integer(promote_type(typeof(rhs), typeof(mod), eltype(weights)))
   return SumModConstraint{T}(sites, T.(weights), convert(T, rhs); mod=convert(T, mod))
 end
 
@@ -130,10 +141,7 @@ struct NotEqualsConstraint{T<:Real} <: AbstractConstraint
 end
 
 function NotEqualsConstraint(sites, values)
-  isempty(values) && throw(ArgumentError("values must not be empty"))
-  T = promote_type(map(typeof, values)...)
-
-  return NotEqualsConstraint{T}(sites, T.(values))
+  return NotEqualsConstraint{eltype(values)}(sites, values)
 end
 
 """

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -207,7 +207,11 @@ struct RelationConstraint <: AbstractConstraint
     @argcheck left != right
     @argcheck relation in VALID_RELATIONS
 
-    return new(left, relation, right)
+    return if left < right
+      new(left, relation, right)
+    else
+      new(right, relation_swap(relation), left)
+    end
   end
 end
 
@@ -294,10 +298,19 @@ const VALID_RELATIONS = (
 )
 
 function relation_holds(lhs, relation, rhs)
-  relation === Symbol("==") && return lhs == rhs
-  relation === Symbol("!=") && return lhs != rhs
-  relation === Symbol("<=") && return lhs <= rhs
-  relation === Symbol(">=") && return lhs >= rhs
+  relation === :(==) && return lhs == rhs
+  relation === :(!=) && return lhs != rhs
+  relation === :(<=) && return lhs <= rhs
+  relation === :(>=) && return lhs >= rhs
+
+  error("unsupported relation: $relation")
+end
+
+function relation_swap(relation)
+  relation === :(==) && return :(==)
+  relation === :(!=) && return :(!=)
+  relation === :(<=) && return :(>=)
+  relation === :(>=) && return :(<=)
 
   error("unsupported relation: $relation")
 end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -45,20 +45,21 @@ struct SumConstraint{T<:Integer} <: AbstractConstraint
   rhs::T
 
   function SumConstraint{T}(sites, weights, relation, rhs) where {T<:Integer}
-    site_vec   = validate_sites(sites)
-    weight_vec = validate_weights(weights)
-    validate_same_length(site_vec, weight_vec, "sites", "weights")
-    relation   = validate_relation(relation)
-    rhs        = validate_rhs(rhs)
+    @argcheck allunique(sites)
+    @argcheck all(>(0), sites)
+    @argcheck length(weights) == length(sites) DimensionMismatch
+    @argcheck all(>=(0), weights)  # WIP: this is only necessary at the DFA level
+    @argcheck rhs >= 0
+    @argcheck relation in VALID_RELATIONS
 
-    weight_vec = T.(weight_vec)
-    rhs        = T(rhs)
+    # Helps reduce the bond dimension
+    weights = T.(weights)
+    rhs     = T(rhs)
+    g       = gcd(rhs, weights...)
+    @. weights = div(weights, g)
+    rhs        = div(rhs, g)
 
-    g = gcd(rhs, weight_vec...)
-    weight_vec .= div.(weight_vec, g)
-    rhs         = div(rhs, g)
-
-    weight_map = Dict{Int,T}(zip(site_vec, weight_vec))
+    weight_map = Dict{Int,T}(zip(sites, weights))
     filter!(p -> !iszero(p.second), weight_map)
 
     return new{T}(weight_map, relation, rhs)
@@ -95,18 +96,23 @@ struct SumModConstraint{T<:Integer} <: AbstractConstraint
   mod::T
 
   function SumModConstraint{T}(sites, weights, rhs; mod) where {T<:Integer}
-    site_vec    = validate_sites(sites)
-    validate_same_length(site_vec, weights, "sites", "weights")
-    modulus     = validate_modulus(mod)
+    @argcheck all(>(0), sites)
+    @argcheck allunique(sites)
+    @argcheck length(weights) == length(sites) DimensionMismatch
+    @argcheck mod >= 1
 
-    modulus        = T(modulus)
-    weight_vec     = @. Base.mod(T(weights), modulus)
-    normalized_rhs = Base.mod(T(rhs), modulus)
+    # Helps reduce the bond dimension
+    weights = T.(weights)
+    rhs     = T(rhs)
+    mod     = T(mod)
 
-    weight_map     = Dict{Int,T}(zip(site_vec, weight_vec))
+    @. weights = Base.mod(weights, mod)
+    rhs        = Base.mod(rhs, mod)
+
+    weight_map = Dict{Int,T}(zip(sites, weights))
     filter!(p -> !iszero(p.second), weight_map)
 
-    return new{T}(weight_map, normalized_rhs, modulus)
+    return new{T}(weight_map, rhs, mod)
   end
 end
 
@@ -129,10 +135,11 @@ struct NotEqualsConstraint{T<:Real} <: AbstractConstraint
   values::Dict{Int, T}
 
   function NotEqualsConstraint{T}(sites, values::AbstractVector{T}) where {T<:Real}
-    site_vec = validate_sites(sites)
-    validate_same_length(site_vec, values, "sites", "values")
+    @argcheck all(>(0), sites)
+    @argcheck allunique(sites)
+    @argcheck length(values) == length(sites) DimensionMismatch
 
-    value_map = Dict{Int,T}(zip(site_vec, values))
+    value_map = Dict{Int,T}(zip(sites, values))
 
     return new{T}(value_map)
   end
@@ -166,11 +173,12 @@ struct AssignmentConstraint{T<:Real} <: AbstractConstraint
   rhs      :: Int
 
   function AssignmentConstraint{T}(sites, values, relation, rhs) where {T<:Real}
-    site_vec = validate_sites(sites)
-    relation = validate_relation(relation)
-    rhs      = Int(validate_rhs(rhs))
+    @argcheck all(>(0), sites)
+    @argcheck allunique(sites)
+    @argcheck rhs >= 0
+    @argcheck relation in VALID_RELATIONS
 
-    return new{T}(site_vec, Set(values), relation, rhs)
+    return new{T}(sites, Set(values), relation, Int(rhs))
   end
 end
 
@@ -193,12 +201,13 @@ struct RelationConstraint <: AbstractConstraint
   relation::Symbol
   right_site::Int
 
-  function RelationConstraint(left_site, relation, right_site)
-    left  = validate_site(left_site, "left_site")
-    right = validate_site(right_site, "right_site")
-    left == right && throw(ArgumentError("relation constraint sites must be distinct"))
+  function RelationConstraint(left, relation, right)
+    @argcheck left  > 0
+    @argcheck right > 0
+    @argcheck left != right
+    @argcheck relation in VALID_RELATIONS
 
-    return new(left, validate_relation(relation), right)
+    return new(left, relation, right)
   end
 end
 
@@ -274,7 +283,7 @@ function constraint_sites(constraint::RelationConstraint)
 end
 
 #----------------------------------------------------------#
-# Constraint Validation
+# Valid relations
 #----------------------------------------------------------#
 
 const VALID_RELATIONS = (
@@ -283,75 +292,6 @@ const VALID_RELATIONS = (
   Symbol("<="),
   Symbol(">="),
 )
-
-function validate_site(site, name)
-  site isa Integer || throw(ArgumentError("$name must be an integer"))
-  site > 0 || throw(ArgumentError("$name must be a positive integer"))
-
-  return Int(site)
-end
-
-function validate_sites(sites)
-  if isempty(sites)
-    throw(ArgumentError("sites must not be empty"))
-  end
-
-  validated = [validate_site(site, "sites") for site in sites]
-  if !allunique(validated)
-    throw(ArgumentError("sites must be unique"))
-  end
-
-  return validated
-end
-
-function validate_same_length(left, right, left_name, right_name)
-  if length(left) != length(right)
-    throw(DimensionMismatch("$left_name and $right_name must have the same length"))
-  end
-end
-
-function validate_weights(weights)
-  if isempty(weights)
-    throw(ArgumentError("weights must not be empty"))
-  end
-  # Nonnegativity is a deliberate v1 contract (issue #56 acceptance criteria):
-  # it keeps the predicate aligned with the nonnegative projection targets used
-  # by the constraint/MPO work tracked in #57. Signed weights (e.g. encoding a
-  # difference `x1 - x2 == 0`) are intentionally out of scope here and should be
-  # revisited together with that lowering, not relaxed in isolation.
-  for (i, weight) in pairs(weights)
-    if weight < 0
-      throw(ArgumentError("Found negative weight w[$(i)] = $(repr(weight)). Weights must be nonnegative."))
-    end
-    if !isinteger(weight)
-      throw(ArgumentError("Found noninteger weight w[$(i)] = $(repr(weight)). Weights must be integer."))
-    end
-  end
-
-  return weights
-end
-
-function validate_modulus(modulus)
-  modulus >= 1 || throw(ArgumentError("mod must be a positive integer"))
-
-  return modulus
-end
-
-function validate_rhs(rhs)
-  if rhs < 0
-    throw(ArgumentError("Found negative rhs = $(repr(rhs)). rhs must be nonnegative."))
-  end
-
-  return rhs
-end
-
-function validate_relation(relation)
-  if !(relation in VALID_RELATIONS)
-    throw(ArgumentError("relation must be one of: $(join(string.(VALID_RELATIONS), ", "))"))
-  end
-
-  return relation
-end
 
 function relation_holds(lhs, relation, rhs)
   relation === Symbol("==") && return lhs == rhs

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -407,12 +407,8 @@ function constraint_to_dfa(constraint::AssignmentConstraint{S}, nsites::Integer,
 end
 
 function constraint_to_dfa(constraint::RelationConstraint, nsites::Integer, alphabet)
-  left  = constraint.left_site
-  right = constraint.right_site
-
-  first_site    = min(left, right)
-  second_site   = max(left, right)
-  left_is_first = left == first_site
+  # Depends on left_site < right_site, as enforced by RelationConstraint
+  (; left_site, right_site, relation) = constraint
 
   states    = alphabet
   initial   = last(states)
@@ -421,13 +417,12 @@ function constraint_to_dfa(constraint::RelationConstraint, nsites::Integer, alph
   id_dict = Dict((q, a) => q for q in states for a in alphabet)
   transitions = fill(id_dict, nsites)
 
-  transitions[first_site] = Dict((q, a) => a for q in states, a in alphabet)
+  transitions[left_site] = Dict((q, a) => a for q in states, a in alphabet)
 
-  transitions[second_site] = Dict(
+  transitions[right_site] = Dict(
     (q, a) => q
     for q in states, a in alphabet
-    if left_is_first ? relation_holds(q, constraint.relation, a) :
-                       relation_holds(a, constraint.relation, q)
+    if relation_holds(q, constraint.relation, a)
   )
 
   return DFA(states, alphabet, initial, accepting, transitions)

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -98,83 +98,9 @@ function permute_dfa!(dfa::DFA, permutation::AbstractVector{<:Integer})
   return dfa
 end
 
-function tensor_from_nonzeros(::Type{T}, inds, nonzeros) where {T}
-  ind_tuple = Tuple(inds)
-  tensor = ITensors.ITensor(T, ind_tuple...)
-
-  for (coordinate, value) in nonzeros
-    coordinate_tuple = Tuple(coordinate)
-    length(coordinate_tuple) == length(ind_tuple) ||
-      throw(DimensionMismatch("nonzero coordinate length must match tensor order"))
-
-    selector = map(i -> ind_tuple[i] => coordinate_tuple[i], eachindex(ind_tuple))
-    tensor[selector...] = tensor[selector...] + convert(T, value)
-  end
-
-  return tensor
-end
-
-function tensor_indices(site, left_link, right_link)
-  return filter(!isnothing, (left_link, site, ITensors.prime(site), right_link))
-end
-
-function tensor_coordinate(symbol_pos::Integer, left_pos, right_pos, left_link, right_link)
-  coordinate = Int[]
-  !isnothing(left_link) && push!(coordinate, left_pos)
-  push!(coordinate, symbol_pos, symbol_pos)
-  !isnothing(right_link) && push!(coordinate, right_pos)
-  return coordinate
-end
-
-function dfa_site_tensor(
-  ::Type{T},
-  site,
-  left_link,
-  right_link,
-  dfa::DFA,
-  step::Integer,
-  state_positions,
-) where {T}
-  inds = tensor_indices(site, left_link, right_link)
-  nonzeros = Tuple{Vector{Int},T}[]
-  table = dfa.transitions[step]
-
-  source_states = isnothing(left_link) ? (dfa.initial,) : dfa.states
-  for source_state in source_states
-    left_pos = isnothing(left_link) ? nothing : state_positions[source_state]
-
-    for (symbol_pos, symbol) in enumerate(dfa.alphabet)
-      next_state = get(table, (source_state, symbol), nothing)
-      isnothing(next_state) && continue
-
-      if isnothing(right_link)
-        next_state in dfa.accepting || continue
-        push!(
-          nonzeros,
-          (tensor_coordinate(symbol_pos, left_pos, nothing, left_link, right_link), one(T)),
-        )
-      else
-        right_pos = state_positions[next_state]
-        push!(
-          nonzeros,
-          (tensor_coordinate(symbol_pos, left_pos, right_pos, left_link, right_link), one(T)),
-        )
-      end
-    end
-  end
-
-  return tensor_from_nonzeros(T, inds, nonzeros)
-end
-
 function validate_dfa_sites(dfa::DFA, sites)
-  if isempty(sites)
-    throw(ArgumentError("sites must not be empty"))
-  end
   if any(site -> ITensors.dim(site) != length(dfa.alphabet), sites)
     throw(DimensionMismatch("each site dimension must match the DFA alphabet size"))
-  end
-  if length(sites) != length(dfa.transitions)
-    throw(DimensionMismatch("DFA transition tables must match the number of sites"))
   end
 end
 
@@ -188,45 +114,55 @@ The physical index basis positions are matched against `dfa.alphabet` in order:
 
 The MPO bond dimension equals `length(dfa.states)`.
 """
-function dfa_to_mpo(::Type{T}, dfa::DFA, sites) where {T}
+function dfa_to_mpo(::Type{T}, dfa::DFA, sites) where T
   validate_dfa_sites(dfa, sites)
-
-  state_positions = Dict(state => i for (i, state) in enumerate(dfa.states))
-  links = [
-    ITensors.Index(length(dfa.states), "Link,DFA,l=$i")
-    for i in 1:max(length(sites) - 1, 0)
-  ]
-
-  tensors = Vector{ITensors.ITensor}(undef, length(sites))
-  for site_position in eachindex(sites)
-    left_link  = site_position == firstindex(sites) ? nothing : links[site_position - 1]
-    right_link = site_position == lastindex(sites)  ? nothing : links[site_position]
-
-    tensors[site_position] = dfa_site_tensor(
-      T,
-      sites[site_position],
-      left_link,
-      right_link,
-      dfa,
-      site_position,
-      state_positions,
-    )
-  end
-
-  return ITensorMPS.truncate!(ITensorMPS.MPO(tensors); cutoff = eps(T))
+  tensors = transition_tensors(T, dfa)
+  return arrays_to_itensor_mpo( tensors, sites)
 end
 
-dfa_to_mpo(dfa::DFA, sites) = dfa_to_mpo(Float64, dfa, sites)
+
+# Turn a stepwise DFA into a sequence of 3-tensors or 4-tensors
+# representing its transition matrices.
+function transition_tensors(::Type{T}, dfa::DFA) where T
+  (; states, alphabet, transitions, initial, accepting) = dfa
+
+  # initial -> states -> states -> ... -> states -> accepting
+  sources(i) = i == firstindex(transitions) ? (initial,)   : states
+  targets(i) = i == lastindex(transitions)  ? (accepting,) : tuple.(states)
+
+  # Turn a 1xkxnxn or kx1xnxn tensor into a kxnxn tensor (used on the boundaries)
+  proper_shape(A) = dropdims(A; dims = Tuple(filter(d -> size(A, d) == 1, (1, 2))))
+
+  return [
+    proper_shape(T[
+      a == b && haskey(transitions[i], (s, a)) && transitions[i][(s, a)] in ts
+      for s  in sources(i),
+          ts in targets(i),
+          a  in alphabet,
+          b  in alphabet
+    ])
+    for i in eachindex(transitions)
+  ]
+end
+
+# Turn a homebrew MPO into an appropriate ITensor.
+# This is the only bridge between ITensor and this module.
+function arrays_to_itensor_mpo(arrays, sites)
+  links = [
+    ITensors.Index(size(A, 1), "Link,l=$i")
+    for (i, A) in pairs(arrays) if i != lastindex(arrays)
+  ]
+  wires(i) = filter(!isnothing, (get(links, i-1, nothing), get(links, i, nothing), sites[i]', sites[i]))
+  itensors = [ ITensors.itensor(A, wires(i)...) for (i, A) in pairs(arrays) ]
+
+  return ITensorMPS.truncate!(ITensorMPS.MPO(itensors); cutoff = eps(real(eltype(first(arrays)))))
+end
 
 """
     projection_mpo([T], constraint, sites; domain)
 
 Build a projection MPO representing a `constraint` applicable to any MPS over `sites`.
-
-The diagonal entry is `one(T)` for computational basis states
-satisfying `constraint`, and `zero(T)` otherwise.
-The current construction is exact and uncompressed.
-Constraint site numbers use the same 1-based register indexing as `sites`.
+Constraint site numbers must use the same 1-based register indexing as `sites`.
 
 # Known constraints
 

--- a/src/projection_mpo.jl
+++ b/src/projection_mpo.jl
@@ -299,6 +299,31 @@ end
 ##############################################
 
 """
+    mapreduce_dfa(f, op, constraint, nsites, alphabet; initial, predicate, states)
+
+Build a DFA by mapping each constrained site symbol through `f` and combining
+the result in a state accumulator with `op`.
+
+The function `f` is assumed to take the `states` to a set where `op`
+acts as a monoid operation, i.e., its associative and `initial` is the identity element.
+The predicate must be a Boolean-valued function deciding whether a state is accepting or not.
+
+This is an internal method encapsulating a common pattern for constraint representation.
+"""
+function mapreduce_dfa(f, op, constraint, nsites, alphabet; initial, predicate, states)
+  accepting = Set(q for q in states if predicate(q))
+
+  id_dict = Dict((q, a) => q for q in states for a in alphabet)
+  transitions = fill(id_dict, nsites)
+
+  for i in constraint_sites(constraint)
+    transitions[i] = Dict((q, a) => op(q, f(i, a)) for q in states, a in alphabet)
+  end
+
+  return DFA(states, alphabet, initial, accepting, transitions)
+end
+
+"""
     constraint_to_dfa(constraint, n, alphabet)
 
 Build a [`DFA`](@ref) recognizing `constraint` with transitions for `n` steps.
@@ -306,96 +331,79 @@ The `alphabet` parameter represents the domain for a constraint's variables.
 """
 function constraint_to_dfa end
 
-function constraint_to_dfa(constraint::SumConstraint{S}, nsites::Integer, alphabet) where {S}
-  if !all(a -> isinteger(a) && a >= 0, alphabet)
+function constraint_to_dfa(constraint::SumConstraint{S}, nsites::Integer, domain) where {S}
+  if !all(a -> isinteger(a) && a >= 0, domain)
     throw(ArgumentError("SumConstraint only supports nonnegative integer domains."))
   end
 
   (; weights, rhs, relation) = constraint
-  beyond    = rhs + one(S)
+  beyond = rhs + one(S)
 
-  states    = zero(S):beyond
-  initial   = zero(S)
-  accepting = Set(q for q in states if relation_holds(q, relation, rhs))
-
-  id_dict = Dict((q, a) => q for q in states for a in alphabet)
-  transitions = fill(id_dict, nsites)
-
-  for site in constraint_sites(constraint)
-    transitions[site] = Dict(
-      (q, a) => min(q + weights[site] * a, beyond)
-      for q in states, a in alphabet
-    )
-  end
-
-  return DFA(states, alphabet, initial, accepting, transitions)
+  return mapreduce_dfa(
+    (i, a) -> weights[i] * S(a),
+    (x, y) -> min(x + y, beyond),
+    constraint,
+    nsites,
+    domain,
+    ;
+    states    = zero(S):beyond,
+    initial   = zero(S),
+    predicate = q -> relation_holds(q, relation, rhs),
+  )
 end
 
-function constraint_to_dfa(constraint::SumModConstraint{S}, nsites::Integer, alphabet) where {S}
-  if !all(isinteger, alphabet)
+function constraint_to_dfa(constraint::SumModConstraint{S}, nsites::Integer, domain) where {S}
+  if !all(isinteger, domain)
     throw(ArgumentError("SumModConstraint only supports integer domains."))
   end
 
   (; weights, rhs) = constraint
   modulus = constraint.mod
 
-  states    = zero(S):(modulus-one(S))
-  initial   = zero(S)
-  accepting = Set(rhs)
-
-  id_dict = Dict((q, a) => q for q in states for a in alphabet)
-  transitions = fill(id_dict, nsites)
-
-  for site in constraint_sites(constraint)
-    transitions[site] = Dict(
-      (q, a) => mod(q + weights[site] * a, modulus)
-      for q in states, a in alphabet
-    )
-  end
-
-  return DFA(states, alphabet, initial, accepting, transitions)
+  return mapreduce_dfa(
+    (i, a) -> mod(weights[i] * a, modulus),
+    (x, y) -> mod(x + y, modulus),
+    constraint,
+    nsites,
+    domain,
+    ;
+    states    = zero(S):(modulus-one(S)),
+    initial   = zero(S),
+    predicate = ==(rhs),
+  )
 end
 
-function constraint_to_dfa(constraint::NotEqualsConstraint{S}, nsites::Integer, alphabet) where {S}
-  states    = [:mismatch, :all_matched]
-  initial   = :all_matched
-  accepting = Set([:mismatch])
+function constraint_to_dfa(constraint::NotEqualsConstraint{S}, nsites::Integer, domain) where {S}
+  (; values) = constraint
 
-  id_dict = Dict((q, a) => q for q in states for a in alphabet)
-  transitions = fill(id_dict, nsites)
-
-  for site in constraint_sites(constraint)
-    target = constraint.values[site]
-
-    transitions[site] = Dict(
-      (q, a) => S(a) == target ? q : :mismatch
-      for q in states, a in alphabet
-    )
-  end
-
-  return DFA(states, alphabet, initial, accepting, transitions)
+  return mapreduce_dfa(
+    (i, a) -> S(a) != values[i],
+    (x, y) -> x | y,
+    constraint,
+    nsites,
+    domain,
+    ;
+    states    = Bool[0, 1],
+    initial   = false,
+    predicate = identity,
+  )
 end
 
-function constraint_to_dfa(constraint::AssignmentConstraint{S}, nsites::Integer, alphabet) where {S}
+function constraint_to_dfa(constraint::AssignmentConstraint{S}, nsites::Integer, domain) where {S}
   (; values, rhs, relation) = constraint
-  beyond    = rhs + one(S)
+  beyond = rhs + one(S)
 
-  states    = zero(S):beyond
-  initial   = zero(S)
-  accepting = Set(q for q in states if relation_holds(q, relation, rhs))
-
-  id_dict = Dict((q, a) => q for q in states for a in alphabet)
-  transitions = fill(id_dict, nsites)
-
-  f(_, a) = S(a in values)
-  for site in constraint_sites(constraint)
-    transitions[site] = Dict(
-      (q, a) => min(q + f(site, a), beyond)
-      for q in states, a in alphabet
-    )
-  end
-
-  return DFA(states, alphabet, initial, accepting, transitions)
+  return mapreduce_dfa(
+    (i, a) -> S(a in values),
+    (x, y) -> min(x + y, beyond),
+    constraint,
+    nsites,
+    domain,
+    ;
+    states    = zero(S):beyond,
+    initial   = zero(S),
+    predicate = q -> relation_holds(q, relation, rhs),
+  )
 end
 
 function constraint_to_dfa(constraint::RelationConstraint, nsites::Integer, alphabet)

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -57,6 +57,13 @@
     @test relation.left_site == 1
     @test relation.relation == Symbol(">=")
     @test relation.right_site == 2
+
+    relation2 = RelationConstraint(2, Symbol(">="), 1)
+    @test relation2 isa RelationConstraint
+    @test relation2 isa AbstractConstraint
+    @test relation2.left_site == 1
+    @test relation2.relation == Symbol("<=")
+    @test relation2.right_site == 2
   end
 
   @testset "Constructor validation" begin

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -60,13 +60,11 @@
   end
 
   @testset "Constructor validation" begin
-    @test_throws ArgumentError AssignmentConstraint(Int[], 1, :(==), 1)
     @test_throws ArgumentError AssignmentConstraint([0], 1, :(==), 1)
     @test_throws ArgumentError AssignmentConstraint([1, 1], 1, :(==), 1)
-    @test_throws ArgumentError AssignmentConstraint([1.0], 1, :(==), 1)
     @test_throws ArgumentError AssignmentConstraint([1], [1], :(==), -1)
-    @test_throws ArgumentError AssignmentConstraint([1], [1], :(==), 1.5)
     @test_throws ArgumentError AssignmentConstraint([1], [1], :(<), 1)
+    @test_throws InexactError  AssignmentConstraint([1], [1], :(==), 1.5)
 
     @test_throws DimensionMismatch SumConstraint([1, 2], [1], Symbol("=="), 1)
     @test_throws ArgumentError SumConstraint([1], [-1], Symbol("=="), 0)
@@ -86,8 +84,8 @@
       @test SumConstraint([1, 2], [1.0, 2.0], 2.0; relation=:(<=)) isa SumConstraint
       @test SumConstraint([1, 2], [1.0, 1.0], 1.0; relation=:(==)) isa SumConstraint
 
-      @test_throws ArgumentError SumConstraint([1, 2], [1.5, 1.0], 2.0; relation=:(<=))
-      @test_throws ArgumentError SumConstraint([1, 2], [1.0, 1.0], 1.5; relation=:(<=))
+      @test_throws InexactError  SumConstraint([1, 2], [1.5, 1.0], 2.0; relation=:(<=))
+      @test_throws InexactError  SumConstraint([1, 2], [1.0, 1.0], 1.5; relation=:(<=))
       @test_throws ArgumentError SumConstraint([1, 2], [1.0, -1.0], 0.0; relation=:(<=))
     end
 

--- a/test/constraints.jl
+++ b/test/constraints.jl
@@ -76,11 +76,11 @@
     @test_throws UndefKeywordError SumConstraint([1, 2], [1, 1], 1)
 
     @test_throws DimensionMismatch SumModConstraint([1, 2], [1], 0; mod = 2)
-    @test_throws ArgumentError SumModConstraint([1], [1.5], 0; mod = 2)
-    @test_throws ArgumentError SumModConstraint([1], [1], 0.5; mod = 2)
-    @test_throws ArgumentError SumModConstraint([1], [1], 0; mod = 0)
-    @test_throws ArgumentError SumModConstraint([1], [1], 0; mod = -2)
-    @test_throws ArgumentError SumModConstraint([1], [1], 0; mod = 2.5)
+    @test_throws ArgumentError SumModConstraint([1], [1], 0;   mod = 0)
+    @test_throws ArgumentError SumModConstraint([1], [1], 0;   mod = -2)
+    @test_throws InexactError  SumModConstraint([1], [1.5], 0; mod = 2)
+    @test_throws InexactError  SumModConstraint([1], [1], 0.5; mod = 2)
+    @test_throws InexactError  SumModConstraint([1], [1], 0;   mod = 2.5)
 
     @testset "SumConstraint floating-point validation" begin
       @test SumConstraint([1, 2], [1.0, 2.0], 2.0; relation=:(<=)) isa SumConstraint


### PR DESCRIPTION
The intent is to remove some "cruft" we've accumulated while developing the constraints API.
The code should become cleaner and easier to extend after this. This lays some grounwork for tackling #117 and #67.

This is a internals-only refactor PR without any new functionality.
Nevertheless, there are some gains listed below


- [x] Normalize SumConstraint parameters by gcd (reduces bond)
- [x] Normalize SumModConstraint parameters by gcd (reduces bond)
- [x] Normalize RelationConstraint order
- [x] Generalize (most) constraint_to_dfa using a mapreduce abstraction
- [x] Clean up the code of dfa_to_mpo


This PR intentionally does not introduce new tests because it should not affect any external API.
